### PR TITLE
Define format for datepicker on Widgets

### DIFF
--- a/src/django_smartbase_admin/admin/widgets.py
+++ b/src/django_smartbase_admin/admin/widgets.py
@@ -160,28 +160,34 @@ class SBAdminNullBooleanSelectWidget(SBAdminBaseWidget, forms.NullBooleanSelect)
 
 class SBAdminDateWidget(SBAdminBaseWidget, forms.DateInput):
     template_name = "sb_admin/widgets/date.html"
+    # when overriding, make sure the format is included in settings.DATE_INPUT_FORMATS
+    js_datepicker_format = "Y-m-d"
 
     def __init__(self, form_field=None, attrs=None):
         super().__init__(
-            form_field, attrs={"class": "input js-datepicker", **(attrs or {})}
+            form_field, attrs={"class": "input js-datepicker", "data-js-datepicker-format": self.js_datepicker_format, **(attrs or {})}
         )
 
 
 class SBAdminTimeWidget(SBAdminBaseWidget, forms.TimeInput):
     template_name = "sb_admin/widgets/time.html"
+    # when overriding, make sure the format is included in settings.TIME_INPUT_FORMATS
+    js_datepicker_format = "H:i"
 
     def __init__(self, form_field=None, attrs=None):
         super().__init__(
-            form_field, attrs={"class": "input js-timepicker", **(attrs or {})}
+            form_field, attrs={"class": "input js-timepicker", "data-js-datepicker-format": self.js_datepicker_format, **(attrs or {})}
         )
 
 
 class SBAdminDateTimeWidget(SBAdminBaseWidget, forms.DateTimeInput):
     template_name = "sb_admin/widgets/datetime.html"
+    # when overriding, make sure the format is included in settings.DATETIME_INPUT_FORMATS
+    js_datepicker_format = "Y-m-d H:i"
 
     def __init__(self, form_field=None, attrs=None):
         super().__init__(
-            form_field, attrs={"class": "input js-datetimepicker", **(attrs or {})}
+            form_field, attrs={"class": "input js-datetimepicker", "data-js-datepicker-format": self.js_datepicker_format, **(attrs or {})}
         )
 
 

--- a/src/django_smartbase_admin/static/sb_admin/src/js/datepicker.js
+++ b/src/django_smartbase_admin/static/sb_admin/src/js/datepicker.js
@@ -59,7 +59,7 @@ export default class Datepicker {
     initWidgets(parentEl=null) {
         const datePickerSelector = {
             '.js-datepicker': {
-                dateFormat: "d.m.Y",
+                defaultDateFormat: "d.m.Y",
                 allowInput: true,
                 plugins: [
                     monthYearViewsPlugin,
@@ -77,13 +77,13 @@ export default class Datepicker {
             '.js-timepicker': {
                 enableTime: true,
                 noCalendar: true,
-                dateFormat: "H:i",
+                defaultDateFormat: "H:i",
                 allowInput: true,
                 time_24hr: true,
             },
             '.js-datetimepicker': {
                 enableTime: true,
-                dateFormat: "d.m.Y H:i",
+                defaultDateFormat: "d.m.Y H:i",
                 allowInput: true,
                 time_24hr: true,
                 plugins: [
@@ -97,7 +97,9 @@ export default class Datepicker {
 
         Object.keys(datePickerSelector).forEach(selector => {
             parentEl.querySelectorAll(selector).forEach(datePickerEl => {
-                this.initFlatPickr(datePickerEl, datePickerSelector[selector])
+                const options = datePickerSelector[selector]
+                options.dateFormat = datePickerEl.getAttribute('data-js-datepicker-format') || options.defaultDateFormat
+                this.initFlatPickr(datePickerEl, options)
             })
         })
     }


### PR DESCRIPTION
This PR fixes a bug on django admin preventing to submit dates, because the default datepicker date format wasn't accepted by Django (defined in `settings.DATE_INPUT_FORMATS`) unless overriden in django `settings` or `formats`.
So I solve the issue by defining the formats in Widgets themselves and passing the value to input elements and using it to initialize the `Datepicker`. This allows even overriding the value for different dates, if needed