### PR TITLE
fix: escape data coming from API to table if not marked as safe

### DIFF
--- a/src/django_smartbase_admin/actions/admin_action_list.py
+++ b/src/django_smartbase_admin/actions/admin_action_list.py
@@ -4,6 +4,8 @@ import math
 from django.core.paginator import Paginator
 from django.db.models import Q
 from django.utils import timezone
+from django.utils.html import escape
+from django.utils.safestring import SafeString
 from django.utils.text import smart_split, unescape_string_literal
 
 from django_smartbase_admin.engine.const import (
@@ -430,6 +432,11 @@ class SBAdminListAction(SBAdminAction):
                 if field.python_formatter:
                     formatted_value = field.python_formatter(object_id, processed_value)
                 row[field.field] = formatted_value
+            for field_key, field_value in row.items():
+                if isinstance(field_value, str) and not isinstance(
+                    field_value, SafeString
+                ):
+                    row[field_key] = escape(field_value)
 
     def get_json_data(self):
         return self.get_data()

--- a/src/django_smartbase_admin/engine/field.py
+++ b/src/django_smartbase_admin/engine/field.py
@@ -100,7 +100,7 @@ class SBAdminField(JSONSerializableMixin):
         list_visible=None,
         list_collapsed=None,
         auto_created=None,
-        formatter: Formatter = None,
+        formatter: Formatter = Formatter.HTML.value,
         tabulator_editor=None,
         python_formatter=None,
         tabulator_options: "TabulatorFieldOptions" = None,
@@ -185,7 +185,6 @@ class SBAdminField(JSONSerializableMixin):
             if self.model_field and not self.annotate:
                 self.annotate = F(field_name)
             self.filter_field = self.filter_field or field_name
-            self.formatter = "html"
         if self.view.model and not self.model_field:
             self.model_field = self.get_model_field_from_model(self.name)
         if (
@@ -225,8 +224,6 @@ class SBAdminField(JSONSerializableMixin):
                 self.python_formatter = datetime_formatter
             if isinstance(self.model_field, BooleanField):
                 self.python_formatter = boolean_formatter
-        if self.python_formatter and not self.formatter:
-            self.formatter = "html"
         self.filter_field = self.filter_field or self.field
         self.init_filter_for_field(configuration)
         self.initialized = True

--- a/src/django_smartbase_admin/engine/field_formatter.py
+++ b/src/django_smartbase_admin/engine/field_formatter.py
@@ -1,6 +1,7 @@
 from enum import Enum
 
 from django.template.defaultfilters import date, time
+from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from django.utils import timezone
 
@@ -38,8 +39,10 @@ def datetime_formatter_with_format(date_format=None, time_format=None):
 
 def boolean_formatter(object_id, value):
     if value:
-        return f'<span class="badge badge-simple badge-positive">{_("Yes")}</span>'
-    return f'<span class="badge badge-simple badge-neutral">{_("No")}</span>'
+        return mark_safe(
+            f'<span class="badge badge-simple badge-positive">{_("Yes")}</span>'
+        )
+    return mark_safe(f'<span class="badge badge-simple badge-neutral">{_("No")}</span>')
 
 
 def format_array(value_list, separator="", badge_type: BadgeType = BadgeType.NOTICE):
@@ -50,7 +53,7 @@ def format_array(value_list, separator="", badge_type: BadgeType = BadgeType.NOT
         if not value:
             continue
         result += f'<span class="badge badge-simple badge-{badge_type.value} mr-4">{value}</span>{separator}'
-    return result
+    return mark_safe(result)
 
 
 def array_badge_formatter(object_id, value_list):
@@ -62,8 +65,10 @@ def newline_separated_array_badge_formatter(object_id, value_list):
 
 
 def rich_text_formatter(object_id, value):
-    return f'<div style="max-width: 500px; white-space: normal;">{value}</div>'
+    return mark_safe(
+        f'<div style="max-width: 500px; white-space: normal;">{value}</div>'
+    )
 
 
 def link_formatter(object_id, value):
-    return f'<a href="{value}">{value}</a>'
+    return mark_safe(f'<a href="{value}">{value}</a>')


### PR DESCRIPTION
Default tabulator formatter is changed to HTML to be able to show `Shoes &amp; Shirts &lt;img src=x onerror=alert(1)&gt;` as `Shoes & Shirts <img src=x onerror=alert(1)>`