### PR TITLE
fix(list): preserve configured filter keys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,37 @@ SBAdminField(
 )
 ```
 
+If an `SBAdminField` points at an admin method that uses `@admin.display(ordering=...)`
+and the field is filterable, **always set `filter_field` explicitly**. The
+`ordering` value is for sorting, not a reliable substitute for filter wiring.
+Without an explicit `filter_field`, pre-filtered list-view config such as the
+"All" tab can be built with the method name instead of the ORM lookup.
+
+```python
+# ❌ BAD - filter key may become "author_display" before field initialization.
+SBAdminField(
+    name="author_display",
+    annotate=F("author__name"),
+    filter_widget=AutocompleteFilterWidget(model=Author),
+)
+
+@admin.display(description=_("Author"), ordering="author")
+def author_display(self, obj_id, value, **kwargs):
+    return value
+
+# ✅ GOOD - filter key is always the intended ORM lookup.
+SBAdminField(
+    name="author_display",
+    annotate=F("author__name"),
+    filter_field="author",
+    filter_widget=AutocompleteFilterWidget(model=Author),
+)
+
+@admin.display(description=_("Author"), ordering="author")
+def author_display(self, obj_id, value, **kwargs):
+    return value
+```
+
 Gotchas:
 
 - **Two `SBAdminField`s must not resolve to the same `filter_field`** — they'd render form inputs with the same `name`/`id` and JS only reaches the first. Caught statically as `sbadmin.W001`.

--- a/src/django_smartbase_admin/audit/tests/test_audit_integration.py
+++ b/src/django_smartbase_admin/audit/tests/test_audit_integration.py
@@ -34,6 +34,7 @@ def make_mock_configuration(restrict_fn=None):
     config = MagicMock()
     config.restrict_queryset = restrict_fn or (lambda qs, **kwargs: qs)
     config.apply_global_filter_to_queryset = lambda qs, *a, **kw: qs
+    config.get_filter_widget = lambda field, default_widget: default_widget
     return config
 
 

--- a/src/django_smartbase_admin/audit/tests/test_audit_permissions.py
+++ b/src/django_smartbase_admin/audit/tests/test_audit_permissions.py
@@ -43,7 +43,6 @@ class BasePermissionsTest(BaseAuditTest):
         AdminAuditLog.objects.all().delete()
 
         self.admin = AdminAuditLogAdmin(AdminAuditLog, MagicMock())
-        self.admin.field_cache = {}
 
         self.group_ct = ContentType.objects.get_for_model(Group)
         self.user_ct = ContentType.objects.get_for_model(User)

--- a/src/django_smartbase_admin/engine/admin_base_view.py
+++ b/src/django_smartbase_admin/engine/admin_base_view.py
@@ -70,7 +70,6 @@ SBADMIN_RELOAD_ON_SAVE_VAR = "sbadmin_reload_on_save"
 
 class SBAdminBaseView(object):
     global_filter_data_map = None
-    field_cache = None
     sbadmin_detail_actions = None
     menu_label: str | None = None
     add_label: str | None = None

--- a/src/django_smartbase_admin/engine/admin_base_view.py
+++ b/src/django_smartbase_admin/engine/admin_base_view.py
@@ -237,6 +237,8 @@ class SBAdminBaseView(object):
         for field in fields_source:
             if not isinstance(field, SBAdminField):
                 field = SBAdminField(name=field)
+            else:
+                field = field.clone()
             field.init_field_static(self, configuration)
             field_cache[field.name] = field
         return field_cache

--- a/src/django_smartbase_admin/engine/admin_base_view.py
+++ b/src/django_smartbase_admin/engine/admin_base_view.py
@@ -227,38 +227,20 @@ class SBAdminBaseView(object):
             raise PermissionDenied
 
     def get_field_map(self, request) -> dict[str, "SBAdminField"]:
-        return self.field_cache
+        return self.init_fields_cache(
+            self.get_sbadmin_list_display(request), request.request_data.configuration
+        )
 
     def init_fields_cache(self, fields_source, configuration, force=False):
         from django_smartbase_admin.engine.field import SBAdminField
-        from django_smartbase_admin.services.thread_local import (
-            SBAdminThreadLocalService,
-        )
 
-        try:
-            request = SBAdminThreadLocalService.get_request()
-        except LookupError:
-            request = None
-        cache_key = self.get_id()
-        if request is not None:
-            request_field_cache = getattr(request, "_sbadmin_field_cache", {})
-            if not force and cache_key in request_field_cache:
-                self.field_cache = request_field_cache[cache_key]
-                return self.field_cache.values()
-
-        fields = []
-        self.field_cache = {}
+        field_cache = {}
         for field in fields_source:
             if not isinstance(field, SBAdminField):
                 field = SBAdminField(name=field)
             field.init_field_static(self, configuration)
-            fields.append(field)
-            self.field_cache[field.name] = field
-        if request is not None:
-            request_field_cache = getattr(request, "_sbadmin_field_cache", {})
-            request_field_cache[cache_key] = self.field_cache
-            request._sbadmin_field_cache = request_field_cache
-        return fields
+            field_cache[field.name] = field
+        return field_cache
 
     def get_action_url(self, action, modifier="template"):
         raise NotImplementedError
@@ -590,9 +572,6 @@ class SBAdminBaseListView(SBAdminBaseView):
 
     def init_view_dynamic(self, request, request_data=None, **kwargs) -> None:
         super().init_view_dynamic(request, request_data, **kwargs)
-        self.init_fields_cache(
-            self.get_sbadmin_list_display(request), request.request_data.configuration
-        )
         self.init_actions(request)
 
     def get_sbadmin_list_display(self, request) -> list[str] | list:
@@ -977,18 +956,20 @@ class SBAdminBaseListView(SBAdminBaseView):
         if not list_filter:
             return all_config
         list_fields = self.get_sbadmin_list_display(request) or []
-        initialized_fields = self.init_fields_cache(
-            list_fields, request.request_data.configuration
+        base_filter = {}
+        name_of_field = (
+            lambda field: getattr(field, "filter_field", None)
+            or getattr(field, "name", None)
+            or field
         )
-        if initialized_fields is not None:
-            list_fields = initialized_fields
-        base_filter = {
-            getattr(field, "filter_field", field): ""
-            for field in list_fields
-            if field in list_filter
-            or getattr(field, "name", None) in list_filter
-            or getattr(field, "filter_field", None) in list_filter
-        }
+        for field in list_fields:
+            if (
+                field in list_filter
+                or getattr(field, "name", None) in list_filter
+                or getattr(field, "filter_field", None) in list_filter
+            ):
+                base_filter[name_of_field(field)] = ""
+
         url_params = None
         if base_filter:
             url_params = {"filterData": base_filter}

--- a/src/django_smartbase_admin/engine/admin_view.py
+++ b/src/django_smartbase_admin/engine/admin_view.py
@@ -29,7 +29,6 @@ class SBAdminView(SBAdminBaseQuerysetMixin, SBAdminBaseView):
     ordering = None
     list_template_name = "sb_admin/actions/list.html"
     sub_views = None
-    field_cache = None
 
     request_data = None
 

--- a/src/django_smartbase_admin/engine/field.py
+++ b/src/django_smartbase_admin/engine/field.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from copy import copy
 from typing import Any
 
 from django.core.exceptions import FieldDoesNotExist, FieldError, ImproperlyConfigured
@@ -164,6 +165,12 @@ class SBAdminField(JSONSerializableMixin):
         self.python_formatter = python_formatter
         self.tabulator_options = tabulator_options
         self.xlsx_options = xlsx_options
+
+    def clone(self):
+        field = copy(self)
+        if self.filter_widget:
+            field.filter_widget = copy(self.filter_widget)
+        return field
 
     def init_filter_for_field(self, configuration):
         filter_widget = getattr(self, "filter_widget", None)


### PR DESCRIPTION
Avoid initializing list fields while building default filter params so admin display ordering cannot replace the filter field.