### PR TITLE
Process permissions before registering nested form-view actions to prevent auth bypass

### DIFF
--- a/src/django_smartbase_admin/audit/tests/test_action_processing.py
+++ b/src/django_smartbase_admin/audit/tests/test_action_processing.py
@@ -275,7 +275,7 @@ class RowActionIntegrationTests(TestCase):
             f"/actions/PublishArticleView/{IGNORE_LIST_SELECTION}/",
         )
 
-    def test_form_view_actions_are_registered_before_permission_filtering(self):
+    def test_form_view_actions_are_not_registered_when_permission_denied(self):
         view = FakeAdminView(has_action_permission=False)
         action = SBAdminFormViewAction(
             target_view=PublishArticleView,
@@ -286,8 +286,8 @@ class RowActionIntegrationTests(TestCase):
         processed = view.process_list_actions(self.request, [action])
 
         self.assertEqual(processed, [])
-        self.assertTrue(hasattr(view, "PublishArticleView"))
-        self.assertEqual(action.url, "/actions/PublishArticleView/template/")
+        self.assertFalse(hasattr(view, "PublishArticleView"))
+        self.assertIsNone(action.url)
 
     def test_nested_form_view_actions_are_registered(self):
         view = FakeAdminView()

--- a/src/django_smartbase_admin/engine/admin_base_view.py
+++ b/src/django_smartbase_admin/engine/admin_base_view.py
@@ -129,14 +129,16 @@ class SBAdminBaseView(object):
     def process_list_actions(
         self, request, actions: list[SBAdminCustomAction]
     ) -> list[SBAdminCustomAction]:
+        actions = self.process_actions_permissions(request, actions)
         self._register_form_view_actions(actions)
-        return self.process_actions_permissions(request, actions)
+        return actions
 
     def process_row_actions(
         self, request, actions: list[SBAdminCustomAction]
     ) -> list[SBAdminCustomAction]:
+        actions = self.process_actions_permissions(request, actions)
         self._register_form_view_actions(actions)
-        return self.process_actions_permissions(request, actions)
+        return actions
 
     def process_detail_actions(
         self,
@@ -148,14 +150,18 @@ class SBAdminBaseView(object):
             self._materialize_modifier_object_id(action, object_id)
             for action in actions
         ]
+        materialized_actions = self.process_actions_permissions(
+            request, materialized_actions
+        )
         self._register_form_view_actions(materialized_actions)
-        return self.process_actions_permissions(request, materialized_actions)
+        return materialized_actions
 
     def process_inline_actions(
         self, request, actions: list[SBAdminCustomAction]
     ) -> list[SBAdminCustomAction]:
+        actions = self.process_actions_permissions(request, actions)
         self._register_form_view_actions(actions)
-        return self.process_actions_permissions(request, actions)
+        return actions
 
     def _register_form_view_actions(self, actions: list[SBAdminCustomAction]) -> None:
         for action in actions:
@@ -199,8 +205,9 @@ class SBAdminBaseView(object):
     def process_actions(
         self, request, actions: list[SBAdminCustomAction]
     ) -> list[SBAdminCustomAction]:
+        actions = self.process_actions_permissions(request, actions)
         self._register_form_view_actions(actions)
-        return self.process_actions_permissions(request, actions)
+        return actions
 
     def process_actions_permissions(
         self, request, actions: list[SBAdminCustomAction]


### PR DESCRIPTION
### Motivation
- A recursive registration step exposed nested `SBAdminFormViewAction` target views as callable methods on the admin view before permission filtering, allowing hidden/denied parent actions to still make child endpoints directly invocable.  
- The change aims to ensure the parent/container action permission remains an effective authorization gate for nested form actions by avoiding premature registration of denied actions.

### Description
- Call `process_actions_permissions(request, actions)` before `_register_form_view_actions(actions)` in `process_list_actions`, `process_row_actions`, `process_inline_actions`, `process_actions`, and materialized detail action processing to ensure only permitted actions are registered.  
- Adjust `process_detail_actions` to materialize modifier `object_id`, filter by permission, then register form-view actions for the remaining actions.  
- Update tests in `src/django_smartbase_admin/audit/tests/test_action_processing.py` by replacing `test_form_view_actions_are_registered_before_permission_filtering` with `test_form_view_actions_are_not_registered_when_permission_denied`, asserting that denied form-view actions are not attached to the view and `action.url` is `None`.  
- Modified files: `src/django_smartbase_admin/engine/admin_base_view.py` and `src/django_smartbase_admin/audit/tests/test_action_processing.py`.

### Testing
- Ran `PYTHONPATH=src pytest -q src/django_smartbase_admin/audit/tests/test_action_processing.py` in this environment but test collection failed due to a missing runtime dependency (`easy_thumbnails`), so the updated tests could not be executed here.  
- The test change is limited and asserts that denied actions are not registered and URLs are not populated, and should pass once test dependencies are available in the CI/test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0783cb5c088323bf18db547bf5a332)