### PR TITLE
fix(dynamic-regions): prevent form data leakage via GET query strings

### DIFF
--- a/src/django_smartbase_admin/admin/admin_base.py
+++ b/src/django_smartbase_admin/admin/admin_base.py
@@ -32,7 +32,7 @@ from django.forms.models import (
     _get_foreign_key,
     modelform_factory,
 )
-from django.http import HttpResponse, HttpResponseBadRequest
+from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseNotAllowed
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
 from django.urls import reverse, NoReverseMatch, resolve
@@ -652,9 +652,10 @@ class SBAdminInlineAndAdminCommon(SBAdminFormFieldWidgetsMixin):
 
     @sbadmin_action
     def sbadmin_dynamic_region(self, request, modifier):
-        region_name = request.GET.get(SBADMIN_DYNAMIC_REGION_PARAM) or request.POST.get(
-            SBADMIN_DYNAMIC_REGION_PARAM
-        )
+        if request.method != "POST":
+            return HttpResponseNotAllowed(["POST"])
+
+        region_name = request.POST.get(SBADMIN_DYNAMIC_REGION_PARAM)
         if not region_name:
             return HttpResponseBadRequest(f"Missing {SBADMIN_DYNAMIC_REGION_PARAM}.")
 
@@ -663,7 +664,7 @@ class SBAdminInlineAndAdminCommon(SBAdminFormFieldWidgetsMixin):
             return HttpResponse("", status=404)
 
         form_class = self.get_dynamic_region_form_class(request, obj)
-        data = request.POST if request.method == "POST" else request.GET
+        data = request.POST
         form_kwargs = self.get_dynamic_region_form_kwargs(
             request, form_class, data, obj
         )

--- a/src/django_smartbase_admin/engine/dynamic_forms.py
+++ b/src/django_smartbase_admin/engine/dynamic_forms.py
@@ -447,7 +447,8 @@ class SBAdminDynamicFormMixin:
                 continue
             widget = self.fields[field_name].widget
             attrs = widget.attrs
-            attrs.setdefault("hx-get", endpoint)
+            attrs.pop("hx-get", None)
+            attrs.setdefault("hx-post", endpoint)
             attrs.setdefault(
                 "hx-trigger",
                 getattr(widget, "dynamic_region_trigger_event", "change"),

--- a/src/django_smartbase_admin/engine/modal_view.py
+++ b/src/django_smartbase_admin/engine/modal_view.py
@@ -88,7 +88,7 @@ class ActionModalView(FormView):
         form_kwargs["initial"] = {
             **form_kwargs.get("initial", {}),
             **dynamic_region_initial_from_data(
-                form_class, request.GET, form_kwargs=probe_kwargs
+                form_class, request.POST, form_kwargs=probe_kwargs
             ),
         }
         form_kwargs.pop("data", None)
@@ -96,10 +96,6 @@ class ActionModalView(FormView):
         return form_class(**form_kwargs)
 
     def get(self, request, *args, **kwargs):
-        if region_name := request.GET.get(SBADMIN_DYNAMIC_REGION_PARAM):
-            return self.build_dynamic_region_response(
-                request, self.get_dynamic_region_form(request), region_name
-            )
         return super().get(request, *args, **kwargs)
 
     def get_form_class(self):
@@ -117,6 +113,11 @@ class ActionModalView(FormView):
         return fake_form_class
 
     def post(self, request, *args, **kwargs):
+        if region_name := request.POST.get(SBADMIN_DYNAMIC_REGION_PARAM):
+            return self.build_dynamic_region_response(
+                request, self.get_dynamic_region_form(request), region_name
+            )
+
         form = self.get_form()
         if form.is_valid():
             try:

--- a/src/django_smartbase_admin/tests/test_dynamic_forms.py
+++ b/src/django_smartbase_admin/tests/test_dynamic_forms.py
@@ -808,10 +808,10 @@ class DynamicFormTests(SimpleTestCase):
         modal = DynamicRegionActionModal(view=FakeView())
         form = modal.get_form_class()(request=request)
 
-        self.assertEqual(form.fields["mode"].widget.attrs["hx-get"], "/modal/action/")
+        self.assertEqual(form.fields["mode"].widget.attrs["hx-post"], "/modal/action/")
 
     def test_action_modal_dynamic_region_initial_is_built_from_request_data(self):
-        request = RequestFactory().get(
+        request = RequestFactory().post(
             "/modal/action/",
             {
                 SBADMIN_DYNAMIC_REGION_PARAM: "details",
@@ -822,7 +822,7 @@ class DynamicFormTests(SimpleTestCase):
         modal = DynamicRegionActionModal(view=FakeView())
         modal.setup(request)
 
-        response = modal.get(request)
+        response = modal.post(request)
         html = response.content.decode()
 
         self.assertIn('name="download_url"', html)
@@ -830,7 +830,7 @@ class DynamicFormTests(SimpleTestCase):
         self.assertNotIn('name="weight"', html)
 
     def test_action_modal_dynamic_region_response_includes_related_regions(self):
-        request = RequestFactory().get(
+        request = RequestFactory().post(
             "/modal/action/",
             {
                 SBADMIN_DYNAMIC_REGION_PARAM: "primary_region",
@@ -842,7 +842,7 @@ class DynamicFormTests(SimpleTestCase):
         modal = CrossFieldsetDynamicRegionModal(view=FakeView())
         modal.setup(request)
 
-        response = modal.get(request)
+        response = modal.post(request)
         html = response.content.decode()
 
         self.assertEqual(response.status_code, 200)
@@ -853,7 +853,7 @@ class DynamicFormTests(SimpleTestCase):
         self.assertEqual(html.count('hx-swap-oob="outerHTML"'), 2)
 
     def test_row_action_modal_dynamic_region_initial_uses_object(self):
-        request = RequestFactory().get(
+        request = RequestFactory().post(
             "/modal/row/123/",
             {
                 SBADMIN_DYNAMIC_REGION_PARAM: "row_details",
@@ -863,7 +863,7 @@ class DynamicFormTests(SimpleTestCase):
         modal = RowObjectDynamicRegionModal(view=FakeView())
         modal.setup(request, modifier="123")
 
-        response = modal.get(request)
+        response = modal.post(request)
         html = response.content.decode()
 
         self.assertIn('name="email"', html)
@@ -961,7 +961,7 @@ class DynamicFormTests(SimpleTestCase):
     @override_settings(ROOT_URLCONF=__name__)
     def test_stacked_inline_dynamic_region_fragment_uses_form_prefix(self):
         model_admin = dynamic_region_admin_site._registry[DynamicRegionInlineParent]
-        request = RequestFactory().get(
+        request = RequestFactory().post(
             "/admin/django_smartbase_admin/dynamicregioninlineparent/inline/"
             "sbadmin_dynamic_region/add/",
             data={
@@ -1084,7 +1084,7 @@ class DynamicFormTests(SimpleTestCase):
         form = ViewBackedForm(request=self.request)
         attrs = form.fields["mode"].widget.attrs
 
-        self.assertEqual(attrs["hx-get"], "/sb-admin/sbadmin_dynamic_region/add")
+        self.assertEqual(attrs["hx-post"], "/sb-admin/sbadmin_dynamic_region/add")
         self.assertEqual(attrs["hx-target"], "#sbadmin-dynamic-region-details")
         self.assertEqual(attrs["hx-include"], "closest form")
         self.assertEqual(attrs["hx-swap"], "none")


### PR DESCRIPTION
### Motivation
- Dynamic-region triggers were wired with `hx-get` plus `hx-include="closest form"`, causing full form state (including secrets) to be serialized into URL query strings and logged. 
- Server-side handlers reconstructed initial values from `request.GET`, making query-string leakage exploitable. 
- The change aims to stop sensitive form data appearing in URLs while preserving dynamic-region behavior.

### Description
- Switched client-side trigger wiring to use `hx-post` and remove any stale `hx-get` when binding dynamic-region trigger widgets in `src/django_smartbase_admin/engine/dynamic_forms.py`.
- Restricted the admin dynamic-region action to only accept `POST` and read refresh parameters from `request.POST` in `src/django_smartbase_admin/admin/admin_base.py` and added `HttpResponseNotAllowed` handling.
- Updated modal dynamic-region flow to reconstruct form initial state from `request.POST` and to process region-refresh requests in `POST` in `src/django_smartbase_admin/engine/modal_view.py`.

### Testing
- Ran `python -m pytest src/django_smartbase_admin/tests/test_dynamic_forms.py -q` which failed during Django setup/collection due to missing project settings and app initialization in this environment. (failure)
- Ran the same test with `DJANGO_SETTINGS_MODULE=tests.settings` which failed with `AppRegistryNotReady` during collection. (failure)
- Ran the project test runner via `python runtests.py ...` which could not complete because the environment lacks `psycopg`/`psycopg2` test dependencies. (failure)
- Note: automated test execution could not be completed in this container; changes are minimal and focused on switching GET→POST for dynamic-region refreshes and should be validated by the full test suite in CI or a configured local environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c61614f6c8323808551a1fbd119f1)