### PR TITLE
Fix disabled clearable file widget mutation paths

### DIFF
--- a/src/django_smartbase_admin/static/sb_admin/src/js/main.js
+++ b/src/django_smartbase_admin/static/sb_admin/src/js/main.js
@@ -542,6 +542,9 @@ class Main {
 
             const deleteButton = fileInput.querySelector('.js-input-file-delete')
             deleteButton?.addEventListener('click', () => {
+                if (input?.disabled || delete_checkbox?.disabled) {
+                    return
+                }
                 input.value = ""
                 input.dispatchEvent(new Event('change'))
                 if (delete_checkbox) {

--- a/src/django_smartbase_admin/templates/sb_admin/widgets/clearable_file_input.html
+++ b/src/django_smartbase_admin/templates/sb_admin/widgets/clearable_file_input.html
@@ -5,7 +5,7 @@
     <div class="input-file js-input-file{% if widget.is_initial %} filled{% endif %}{% if widget.attrs.readonly %} input-file--readonly{% endif %}">
         <div class="flex items-center flex-shrink-0">
             <img src="{% if widget.is_initial %}{% get_file_preview_image widget.value %}{% endif %}" alt="" class="js-input-file-image border-dark-300 object-cover w-64 h-64 rounded-xs mr-16" width="64" height="64">
-            {% if not widget.attrs.readonly %}
+            {% if not widget.attrs.readonly and not widget.attrs.disabled %}
             <span class="w-40 h-40 flex items-center justify-center rounded-full mr-16 js-input-file-empty input-file-upload-icon">
                 <svg class="w-24 h-24">
                     <use xlink:href="#Upload"></use>
@@ -13,7 +13,7 @@
             </span>
             {% endif %}
         </div>
-        {% if not widget.attrs.readonly %}
+        {% if not widget.attrs.readonly and not widget.attrs.disabled %}
         <div class="js-input-file-empty">
             <span class="flex items-center">
                     <button type="button" class="btn btn-primary-light btn-tiny">{% trans 'Add file' %}</button>
@@ -30,12 +30,12 @@
                     <a class="link" target="_blank" href="{{ widget.value.url }}">{{ widget.value }}</a>
                 {% endif %}
             </div>
-            {% if not widget.attrs.readonly %}
+            {% if not widget.attrs.readonly and not widget.attrs.disabled %}
             <div class="flex flex-wrap gap-4 mt-8">
                 <label for="{{ widget.attrs.id }}" type="button" class="btn btn-tiny input-file-edit-btn">{% trans 'Edit' %}</label>
                 <button type="button" class="btn btn-tiny btn-destructive js-input-file-delete">{% trans 'Delete' %}</button>
                 {% if widget.is_initial and not widget.required %}
-                    <input type="checkbox" class="hidden" name="{{ widget.checkbox_name }}" id="{{ widget.checkbox_id }}">
+                    <input type="checkbox" class="hidden" name="{{ widget.checkbox_name }}" id="{{ widget.checkbox_id }}"{% if widget.attrs.disabled %} disabled{% endif %}>
                 {% endif %}
             </div>
             {% endif %}


### PR DESCRIPTION
### Motivation

- A regression allowed disabled or readonly file widgets to still accept uploads or request clears via a hidden clear checkbox and client-side delete handler, which breaks widget-level editability assumptions.
- The intention is to prevent client-side mutation paths when a widget is presented as disabled/readonly without changing server-side form semantics.

### Description

- Update the clearable file input template to hide upload/edit/delete controls when `widget.attrs.disabled` is set in addition to `widget.attrs.readonly`.
- Restore propagation of the `disabled` attribute to the hidden clear checkbox so a disabled widget cannot submit a clear request via `{{ widget.checkbox_name }}`.
- Add a defensive guard in the delete-button handler in `static/sb_admin/src/js/main.js` so the handler no-ops if the file `input` or the clear checkbox is disabled.

### Testing

- Ran `python -m compileall -q src/django_smartbase_admin` and the codebase compiled successfully with no syntax errors.
- No automated unit tests were added or modified as part of this minimal security fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d55e173008323a24c832b2276ffda)