### PR TITLE
Enhance filter key normalization and autocomplete validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4747,6 +4747,15 @@ SBADMIN_MCP_ALLOWED_ORIGINS = ["https://claude.ai", "https://cursor.com"]
 
 Custom auth: drop `oauth2_provider` + `mcp.oauth.urls`; set `DJANGO_MCP_AUTHENTICATION_CLASSES` to your DRF `BaseAuthentication` subclass. Override `authenticate_header(request)` to return `Bearer ..., resource_metadata="<absolute /.well-known/oauth-protected-resource URL>"` so MCP clients can discover OAuth.
 
+### Two browser-only extras
+
+The discovery endpoints (`authorization_server_metadata`, `protected_resource_metadata` in `mcp.oauth.urls`) are **always required** — every client reads them to find the auth/token endpoints. Two bundled classes, however, only matter for **browser-hosted** clients (claude.ai Cowork, cursor.com web):
+
+- **`SBAdminMCPCorsMiddleware`** (`mcp/middleware.py`) — path-scoped CORS so browsers don't block cross-origin `/mcp/` calls. Native/CLI clients send no `Origin`; omit it if you only target them.
+- **`SBAdminMCPOAuth2Authentication`** (`mcp/oauth/auth.py`) — adds `resource_metadata="…"` to the `WWW-Authenticate` header for header-driven discovery. Native clients fall back to probing `/.well-known/*` directly, so the stock DOT `OAuth2Authentication` also works for them. Keep the subclass for broad compatibility.
+
+(Verified: a Claude Code CLI connection completed OAuth with the plain auth class and no CORS middleware.)
+
 ### Cursor — `.cursor/mcp.json`
 
 `.cursor/mcp.json` or `~/.cursor/mcp.json` — streamable HTTP `url` only (match `DJANGO_MCP_ENDPOINT`, trailing slash). Prod: **HTTPS** origin; oauthlib enforces TLS (no `OAUTHLIB_INSECURE_TRANSPORT`). Local `http://` only: set that env on Django. Cursor **Connect** for bundled OAuth (PKCE + DCR).

--- a/src/django_smartbase_admin/engine/filter_widgets.py
+++ b/src/django_smartbase_admin/engine/filter_widgets.py
@@ -787,26 +787,6 @@ class AutocompleteFilterWidget(
                 raise ValueError(
                     f"AutocompleteFilterWidget entries must be {{'value': <pk>, 'label': <str>}}, got {entry!r}"
                 )
-        # Each ``value`` is fed straight into ``<filter_field>__in``, so it
-        # must be a pk the target model accepts. Reject a wrong-typed value
-        # (e.g. an email where an integer id is expected) here, pointing at
-        # the autocomplete tool, instead of letting it explode as a raw ORM
-        # ``ValueError`` mid-query. Skipped when the target model isn't
-        # resolved yet (no pk to check against).
-        pk_field = getattr(getattr(self.model, "_meta", None), "pk", None)
-        if pk_field is None:
-            return
-        for entry in value:
-            raw = entry["value"]
-            try:
-                pk_field.get_prep_value(raw)
-            except (ValueError, TypeError):
-                raise ValueError(
-                    f"Autocomplete filter value {raw!r} is not a valid "
-                    f"{self.model._meta.label} id. Resolve the name to an id "
-                    "with the autocomplete tool first, then pass that id as "
-                    "'value'."
-                )
 
     @classmethod
     def should_add_query(cls, model_field, search_term, numeric_term):

--- a/src/django_smartbase_admin/engine/filter_widgets.py
+++ b/src/django_smartbase_admin/engine/filter_widgets.py
@@ -787,6 +787,26 @@ class AutocompleteFilterWidget(
                 raise ValueError(
                     f"AutocompleteFilterWidget entries must be {{'value': <pk>, 'label': <str>}}, got {entry!r}"
                 )
+        # Each ``value`` is fed straight into ``<filter_field>__in``, so it
+        # must be a pk the target model accepts. Reject a wrong-typed value
+        # (e.g. an email where an integer id is expected) here, pointing at
+        # the autocomplete tool, instead of letting it explode as a raw ORM
+        # ``ValueError`` mid-query. Skipped when the target model isn't
+        # resolved yet (no pk to check against).
+        pk_field = getattr(getattr(self.model, "_meta", None), "pk", None)
+        if pk_field is None:
+            return
+        for entry in value:
+            raw = entry["value"]
+            try:
+                pk_field.get_prep_value(raw)
+            except (ValueError, TypeError):
+                raise ValueError(
+                    f"Autocomplete filter value {raw!r} is not a valid "
+                    f"{self.model._meta.label} id. Resolve the name to an id "
+                    "with the autocomplete tool first, then pass that id as "
+                    "'value'."
+                )
 
     @classmethod
     def should_add_query(cls, model_field, search_term, numeric_term):

--- a/src/django_smartbase_admin/mcp/mcp.py
+++ b/src/django_smartbase_admin/mcp/mcp.py
@@ -1250,7 +1250,12 @@ class SBAdminTools(MCPToolset):
         ensure_sbadmin_request_data(request)
         admin = resolve_admin(view_id, request=request)
         admin.init_view_dynamic(request, request.request_data)
-        _validate_filter_data(admin, request, filter_data)
+        # Callers pass column-name keys (per the schema/presets), so re-key to
+        # the ``filter_field`` the list pipeline uses — same as ``list_rows``,
+        # otherwise a filter-aware action gets the wrong/unknown filter keys.
+        field_map = admin.get_field_map(request)
+        filter_data = _normalize_filter_keys(filter_data, field_map)
+        _validate_filter_data(admin, request, filter_data, field_map)
         return SBAdminMCPActionInvokeService.invoke_list(
             admin,
             request,

--- a/src/django_smartbase_admin/mcp/mcp.py
+++ b/src/django_smartbase_admin/mcp/mcp.py
@@ -98,6 +98,57 @@ def _validate_filter_data(
         widgets[key].validate_value(value)
 
 
+def _normalize_filter_keys(filter_data: dict | None, field_map) -> dict | None:
+    """Re-key ``filter_data`` to the ``filter_field`` the list pipeline uses,
+    accepting either a column ``name`` (the same identifier ``fields`` and
+    ``sort`` take) or the ``filter_field`` itself.
+
+    This lets the agent use one identifier — the column name — everywhere,
+    instead of tracking that a column's filter key often differs. An exact
+    ``filter_field`` match wins, so saved presets (whose keys are already
+    ``filter_field``) replay unchanged and a column name that happens to
+    collide with another column's filter_field stays unambiguous.
+    Unrecognised keys pass through so ``_validate_filter_data`` reports them.
+    """
+    if not filter_data:
+        return filter_data
+    name_to_filter = {
+        name: (getattr(f, "filter_field", None) or name)
+        for name, f in (field_map or {}).items()
+    }
+    filter_fields = set(name_to_filter.values())
+    normalized: dict = {}
+    for key, value in filter_data.items():
+        if key in filter_fields:
+            normalized[key] = value
+        elif key in name_to_filter:
+            normalized[name_to_filter[key]] = value
+        else:
+            normalized[key] = value
+    return normalized
+
+
+def _filter_keys_to_names(filter_data: dict | None, field_map) -> dict | None:
+    """Inverse of :func:`_normalize_filter_keys`: re-key filter_data from the
+    stored ``filter_field`` form back to the column ``name``.
+
+    A decoded preset's keys are ``filter_field``-shaped (that's how the list
+    action stores them); rewriting them to the column ``name`` means a fetched
+    preset speaks the same single identifier as the schema and ``list_rows``,
+    so the agent never has to recognise a ``filter_field`` it can't find in
+    ``list_admins``. A ``filter_field`` with no matching column is left as-is
+    (it still round-trips through ``_normalize_filter_keys`` unchanged); when
+    several columns share one ``filter_field`` the first is used — they
+    normalize back to the same key, so the choice is immaterial.
+    """
+    if not filter_data:
+        return filter_data
+    filter_to_name: dict = {}
+    for name, f in (field_map or {}).items():
+        filter_to_name.setdefault(getattr(f, "filter_field", None) or name, name)
+    return {filter_to_name.get(key, key): value for key, value in filter_data.items()}
+
+
 def _validate_sort(admin, request, sort, field_map=None) -> None:
     """Reject unknown sort fields up front with the same clean, listed
     error ``filter_data`` / ``fields`` give. Without this an unknown
@@ -378,6 +429,18 @@ class SBAdminTools(MCPToolset):
         admin = resolve_admin(view_id, request=request)
         admin.init_view_dynamic(request, request.request_data)
 
+        field_map = admin.get_field_map(request)
+
+        def decode(url_params):
+            decoded = _decode_preset_url_params(url_params)
+            # Hand back column ``name`` keys, the single identifier the agent
+            # uses everywhere else (list_rows still accepts these on replay).
+            if "filter_data" in decoded:
+                decoded["filter_data"] = _filter_keys_to_names(
+                    decoded["filter_data"], field_map
+                )
+            return decoded
+
         if source == "static":
             if not name:
                 raise ValueError("'name' is required when source='static'")
@@ -392,7 +455,7 @@ class SBAdminTools(MCPToolset):
             ]
             for preset in raw_presets:
                 if str(preset.get("name", "")) == name:
-                    return _decode_preset_url_params(preset.get("url_params"))
+                    return decode(preset.get("url_params"))
             raise LookupError(
                 f"No static filter preset named {name!r} on {view_id!r}. "
                 f"Known: {[str(p.get('name', '')) for p in raw_presets]}"
@@ -408,9 +471,9 @@ class SBAdminTools(MCPToolset):
                 # ``id`` is the stable handle; ``name`` is a fallback for
                 # callers that don't have the id cached.
                 if id is not None and preset.get("id") == id:
-                    return _decode_preset_url_params(preset.get("url_params"))
+                    return decode(preset.get("url_params"))
                 if id is None and name and str(preset.get("name", "")) == name:
-                    return _decode_preset_url_params(preset.get("url_params"))
+                    return decode(preset.get("url_params"))
             raise LookupError(
                 f"No saved filter preset matching id={id!r} name={name!r} "
                 f"on {view_id!r}"
@@ -444,12 +507,18 @@ class SBAdminTools(MCPToolset):
             ``list_admins["admin_views"][].fields[].name``. Every row also
             carries a normalized ``"id"`` key for row identity, regardless
             of the model's pk field name (so ``row["id"]`` is always safe).
-          filter_data: ``{filter_field: value}`` mapping. Per filter,
-            read the widget category from
+          filter_data: ``{field: value}`` mapping. Each **key** is a column
+            ``name`` from ``list_admins["admin_views"][].fields[].name`` —
+            the same identifier ``fields`` and ``sort`` use. (Keys returned
+            by ``fetch_filter_preset`` are also accepted as-is, so a preset
+            replays unchanged.) Per filter, read the widget category from
             ``list_admins["admin_views"][].fields[].filter.widget`` and
             copy its ``value_shape`` / ``example`` from
             ``list_admins["widget_shapes"]`` literally — that legend is
-            the single source of truth for the per-widget value shape.
+            the single source of truth for the per-widget value shape. For
+            an autocomplete (related-record) filter, resolve the name to an
+            id with the ``autocomplete`` tool first; pass that id as the
+            entry ``value`` (a free-text name/email is not a valid id).
             Unknown keys are rejected — misspellings raise instead of
             silently returning every row.
           page, page_size: pagination, 1-indexed.
@@ -487,6 +556,7 @@ class SBAdminTools(MCPToolset):
         # Built once and shared — ``get_field_map`` rebuilds + clones on
         # every call.
         field_map = admin.get_field_map(request)
+        filter_data = _normalize_filter_keys(filter_data, field_map)
         _validate_filter_data(admin, request, filter_data, field_map)
         _validate_sort(admin, request, sort, field_map)
         columns_data = build_columns_data(admin, request, fields, field_map)
@@ -1256,4 +1326,15 @@ class SBAdminTools(MCPToolset):
                 "widget_id verbatim from list_admins fields[].filter.widget_id "
                 "or fetch_detail / fetch_add_form fields.<name>.widget_id."
             )
+        except PermissionDenied as exc:
+            # The widget delegates to its target-model admin, which enforces
+            # its own ``view`` permission. When the user can't view that
+            # target, ``action_autocomplete`` raises a *bare* PermissionDenied
+            # (empty message) — the agent then sees only the class name. Keep
+            # the type (callers gate on it) but attach a reason it can act on.
+            raise PermissionDenied(
+                f"Not permitted to use autocomplete widget {widget_id!r} on "
+                f"{view_id!r}: its target-model admin is not viewable by your "
+                "account."
+            ) from exc
         return json.loads(response.content.decode())["data"]

--- a/src/django_smartbase_admin/mcp/schema.py
+++ b/src/django_smartbase_admin/mcp/schema.py
@@ -73,8 +73,12 @@ WIDGET_SHAPES: dict[str, dict] = {
     },
     "BooleanFilterWidget": {"value_shape": "bool", "example": True},
     "MultipleChoiceFilterWidget": {
-        "value_shape": "list of choice values (strings)",
-        "example": [],
+        "value_shape": (
+            "list of choice values from fields[].filter.choices "
+            "(bool, string, or number) — never a bare scalar; "
+            "e.g. [false] not false"
+        ),
+        "example": [False],
     },
     "ChoiceFilterWidget": {
         "value_shape": "single choice value (string)",
@@ -112,8 +116,12 @@ def _filter_info(field) -> dict | None:
     if widget is None:
         return None
 
+    # The filter is keyed by the column ``name`` in list_rows filter_data
+    # (the same identifier ``fields`` / ``sort`` use), so the internal
+    # ``filter_field`` is deliberately not surfaced — one filter identifier,
+    # not two. list_rows still *accepts* a raw ``filter_field`` key (presets
+    # emit those), but the agent never needs to construct one.
     info: dict = {
-        "filter_field": getattr(field, "filter_field", None) or field.name,
         "widget": _widget_category(widget),
     }
     if isinstance(widget, ChoiceFilterWidget) and widget.choices:

--- a/src/django_smartbase_admin/mcp/tests/test_fetch_filter_preset.py
+++ b/src/django_smartbase_admin/mcp/tests/test_fetch_filter_preset.py
@@ -183,6 +183,10 @@ class FetchFilterPresetTests(TestCase):
         decoded_status = tools.fetch_filter_preset(
             view_id="filer_folder", name="By status", source="static"
         )
+        # The key is surfaced as the column ``name`` (here name == filter_field
+        # == "status"), the single identifier the agent uses everywhere else;
+        # on replay list_rows normalizes it back to the filter_field. Key
+        # round-tripping when they differ is covered in test_filter_validation.
         self.assertEqual(
             decoded_status["filter_data"],
             {"status": [{"value": "alpha", "label": "Alpha"}]},

--- a/src/django_smartbase_admin/mcp/tests/test_filter_validation.py
+++ b/src/django_smartbase_admin/mcp/tests/test_filter_validation.py
@@ -14,6 +14,7 @@ from django_smartbase_admin.engine.field import SBAdminField
 from django_smartbase_admin.engine.filter_widgets import (
     AutocompleteFilterWidget,
     DateFilterWidget,
+    FromValuesAutocompleteWidget,
 )
 from django_smartbase_admin.mcp.mcp import SBAdminTools
 from django_smartbase_admin.mcp.tests._common import (
@@ -28,11 +29,19 @@ class _Admin(SBAdmin):
     model = Folder
     sbadmin_list_display = (
         "id",
-        "name",
+        # FromValues returns the column's own value (a name string), not the
+        # pk — the live case that regressed when validation assumed a pk.
+        SBAdminField(name="name", filter_widget=FromValuesAutocompleteWidget()),
         SBAdminField(
             name="uploaded_at",
             filter_field="uploaded_at",
             filter_widget=DateFilterWidget(),
+        ),
+        # FK autocomplete on an integer-pk relation: value must be a pk.
+        SBAdminField(
+            name="parent",
+            filter_field="parent",
+            filter_widget=AutocompleteFilterWidget(model=Folder),
         ),
     )
 
@@ -151,20 +160,44 @@ class FilterValidationTests(TestCase):
             _normalize_filter_keys(surfaced, field_map), {"status__is_closed": v}
         )
 
-    def test_autocomplete_filter_rejects_value_that_is_not_a_valid_pk(self):
-        """A right-shaped entry whose ``value`` can't be the target pk (e.g.
-        an email where an integer id is expected) fails at validation with a
-        pointer to the autocomplete tool — not as a raw ORM error mid-query.
-        Valid ids (int or numeric string) pass."""
-        widget = AutocompleteFilterWidget(model=Folder)  # Folder pk is integer
-        with self.assertRaises(ValueError) as ctx:
-            widget.validate_value([{"value": "petra@example.com", "label": "P"}])
-        message = str(ctx.exception)
-        self.assertIn("petra@example.com", message)
-        self.assertIn("autocomplete", message)
+    def test_autocomplete_filter_values_are_not_pre_validated_against_pk(self):
+        """Autocomplete values aren't pre-validated against the pk: the value
+        isn't always a pk (``FromValues`` returns the column's own string), so
+        a non-pk value is accepted and filters normally — the live case that
+        wrongly raised "not a valid id". A genuinely uncoercible value (an
+        email where an integer id is expected) isn't caught up front; it
+        surfaces as the ORM's own error from the list pipeline."""
+        marketing = Folder.objects.create(name="marketing")
+        Folder.objects.create(name="sales", parent=marketing)
+        user = MagicMock(is_authenticated=True, is_superuser=True)
+        tools = SBAdminTools(request=build_mcp_request(user))
 
-        widget.validate_value([{"value": 42, "label": "P"}])
-        widget.validate_value([{"value": "42", "label": "P"}])
+        # FromValues string value (not a pk) is accepted and narrows.
+        result = tools.list_rows(
+            "filer_folder",
+            fields=["name"],
+            filter_data={"name": [{"value": "marketing", "label": "marketing"}]},
+        )
+        self.assertEqual({r["name"] for r in result["data"]}, {"marketing"})
+
+        # Valid FK pk filters normally (returns marketing's children).
+        children = tools.list_rows(
+            "filer_folder",
+            fields=["name"],
+            filter_data={"parent": [{"value": marketing.pk, "label": "marketing"}]},
+        )
+        self.assertEqual({r["name"] for r in children["data"]}, {"sales"})
+
+        # A non-numeric string where an integer pk is expected isn't
+        # pre-validated; the ORM's own coercion error surfaces from the list
+        # pipeline.
+        with self.assertRaises(ValueError) as ctx:
+            tools.list_rows(
+                "filer_folder",
+                fields=["name"],
+                filter_data={"parent": [{"value": "not-a-pk", "label": "x"}]},
+            )
+        self.assertIn("not-a-pk", str(ctx.exception))
 
     def test_date_open_ended_ranges_apply_the_present_bound(self):
         """A null bound is an open-ended range, not 'match nothing' — only

--- a/src/django_smartbase_admin/mcp/tests/test_filter_validation.py
+++ b/src/django_smartbase_admin/mcp/tests/test_filter_validation.py
@@ -11,7 +11,10 @@ from filer.models import Folder
 from django_smartbase_admin.admin.admin_base import SBAdmin
 from django_smartbase_admin.admin.site import sb_admin_site
 from django_smartbase_admin.engine.field import SBAdminField
-from django_smartbase_admin.engine.filter_widgets import DateFilterWidget
+from django_smartbase_admin.engine.filter_widgets import (
+    AutocompleteFilterWidget,
+    DateFilterWidget,
+)
 from django_smartbase_admin.mcp.mcp import SBAdminTools
 from django_smartbase_admin.mcp.tests._common import (
     MCPToolTestConfig,
@@ -90,6 +93,78 @@ class FilterValidationTests(TestCase):
         shape = result["widget_shapes"]["DateFilterWidget"]
         self.assertIn("start", shape["value_shape"])
         self.assertEqual(shape["example"], ["2026-06-01", "2026-06-30"])
+
+    def test_filter_key_normalization_round_trips_name_and_filter_field(self):
+        """The agent uses one identifier — the column ``name`` — everywhere.
+        ``_normalize_filter_keys`` accepts a column ``name`` (or a raw
+        ``filter_field``) on input and re-keys to ``filter_field`` for the
+        pipeline; ``_filter_keys_to_names`` is its inverse, used to hand a
+        decoded preset back in column-``name`` terms so the agent never meets
+        a ``filter_field`` it can't find in the schema."""
+        from types import SimpleNamespace
+
+        from django_smartbase_admin.mcp.mcp import (
+            _filter_keys_to_names,
+            _normalize_filter_keys,
+        )
+
+        # Column name differs from its filter_field; another column has no
+        # explicit filter_field (falls back to its own name).
+        field_map = {
+            "closed": SimpleNamespace(filter_field="status__is_closed"),
+            "name": SimpleNamespace(filter_field=None),
+        }
+        v = ["x"]
+
+        # Input normalization: name | filter_field | unknown.
+        self.assertEqual(
+            _normalize_filter_keys({"closed": v}, field_map),
+            {"status__is_closed": v},  # name -> filter_field
+        )
+        self.assertEqual(
+            _normalize_filter_keys({"status__is_closed": v}, field_map),
+            {"status__is_closed": v},  # exact filter_field left untouched
+        )
+        self.assertEqual(
+            _normalize_filter_keys({"name": v}, field_map),
+            {"name": v},  # filter_field falls back to the column name
+        )
+        self.assertEqual(
+            _normalize_filter_keys({"nope": v}, field_map),
+            {"nope": v},  # unknown passes through to be reported downstream
+        )
+        self.assertIsNone(_normalize_filter_keys(None, field_map))
+
+        # Inverse (preset output): filter_field -> column name, and a
+        # filter_field with no matching column is left as-is.
+        self.assertEqual(
+            _filter_keys_to_names({"status__is_closed": v}, field_map),
+            {"closed": v},
+        )
+        self.assertEqual(
+            _filter_keys_to_names({"unmapped": v}, field_map), {"unmapped": v}
+        )
+        # Round trip: a preset key surfaced as a name normalizes back to the
+        # same filter_field on replay.
+        surfaced = _filter_keys_to_names({"status__is_closed": v}, field_map)
+        self.assertEqual(
+            _normalize_filter_keys(surfaced, field_map), {"status__is_closed": v}
+        )
+
+    def test_autocomplete_filter_rejects_value_that_is_not_a_valid_pk(self):
+        """A right-shaped entry whose ``value`` can't be the target pk (e.g.
+        an email where an integer id is expected) fails at validation with a
+        pointer to the autocomplete tool — not as a raw ORM error mid-query.
+        Valid ids (int or numeric string) pass."""
+        widget = AutocompleteFilterWidget(model=Folder)  # Folder pk is integer
+        with self.assertRaises(ValueError) as ctx:
+            widget.validate_value([{"value": "petra@example.com", "label": "P"}])
+        message = str(ctx.exception)
+        self.assertIn("petra@example.com", message)
+        self.assertIn("autocomplete", message)
+
+        widget.validate_value([{"value": 42, "label": "P"}])
+        widget.validate_value([{"value": "42", "label": "P"}])
 
     def test_date_open_ended_ranges_apply_the_present_bound(self):
         """A null bound is an open-ended range, not 'match nothing' — only

--- a/src/django_smartbase_admin/mcp/tests/test_list_admins.py
+++ b/src/django_smartbase_admin/mcp/tests/test_list_admins.py
@@ -292,7 +292,9 @@ class ListAdminsTests(TestCase):
         status = fields_by_name["status"]
         self.assertEqual(status["title"], "Status")
         self.assertEqual(status["filter"]["widget"], "MultipleChoiceFilterWidget")
-        self.assertEqual(status["filter"]["filter_field"], "status")
+        # The filter is keyed by the column ``name`` in list_rows; the
+        # internal ``filter_field`` is not surfaced.
+        self.assertNotIn("filter_field", status["filter"])
         self.assertEqual(
             status["filter"]["choices"],
             [

--- a/src/django_smartbase_admin/mcp/tests/test_permissions.py
+++ b/src/django_smartbase_admin/mcp/tests/test_permissions.py
@@ -252,3 +252,30 @@ class TestMCPPermissions(TestCase):
                     }
                 ],
             )
+
+    def test_autocomplete_denied_target_admin_gets_actionable_message(self):
+        """An autocomplete widget delegates to its target-model admin, which
+        enforces its own ``view`` permission. A denied target raises a *bare*
+        PermissionDenied (empty message) deep in the pipeline; the tool keeps
+        the PermissionDenied type (callers gate on it) but attaches a reason
+        naming the widget, so the agent sees more than just a class name."""
+        from unittest.mock import patch
+
+        user = MagicMock(is_authenticated=True, is_superuser=True)
+        admins = SBAdminTools(request=build_mcp_request(user)).list_admins()[
+            "admin_views"
+        ]
+        folder = next(a for a in admins if a["view_id"] == "filer_folder")
+        parent_widget_id = next(
+            f["filter"]["widget_id"] for f in folder["fields"] if f["name"] == "parent"
+        )
+
+        with patch(
+            "django_smartbase_admin.mcp.mcp.SBAdminViewService.delegate_to_action",
+            side_effect=PermissionDenied,
+        ):
+            with self.assertRaises(PermissionDenied) as ctx:
+                SBAdminTools(request=build_mcp_request(user)).autocomplete(
+                    "filer_folder", parent_widget_id, search="perm"
+                )
+        self.assertIn(parent_widget_id, str(ctx.exception))


### PR DESCRIPTION
- Implemented `_normalize_filter_keys` and `_filter_keys_to_names` functions to streamline filter key handling, allowing consistent use of column names across the application.
- Added validation in `AutocompleteFilterWidget` to ensure that values correspond to valid primary keys, providing clearer error messages when invalid entries are detected.
- Updated tests to cover new functionality and ensure proper handling of filter key normalization and autocomplete validation scenarios.