### PR TITLE
feat: auto-format and auto-filter choice fields in SBAdmin list views

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ This document provides key patterns and gotchas for developers and AI assistants
 | [Full-text search (`search_fields`)](#full-text-search-search_fields) | How `search_fields` maps SBAdmin names to ORM lookups and how to avoid duplicate rows |
 | [Selection Actions](#selection-actions-bulk-actions) | Modal forms for bulk operations, `ListActionModalView`, confirmation modals, `SBAdminCustomAction` params, per-action permissions, success/error handling |
 | [Row Actions](#row-actions-per-row-list-buttons) | Per-row icon buttons with `SBAdminRowAction`, `RowActionModalView`, and row-aware enablement |
-| [Field Formatters](#field-formatters) | Badge formatters, `array_badge_formatter`, `BadgeType` options |
+| [Field Formatters](#field-formatters) | Badge formatters, `array_badge_formatter`, `BadgeType` options, automatic choice formatting |
 | [XLSX Export Field Formatting](#xlsx-export-field-formatting) | Per-column Excel cell formats via `XLSXFieldOptions.cell_format` (named, dict, or `SBAdminXLSXFormat`) |
 | [View on Site link in list](#view-on-site-link-in-list) | List column with "View on site" icon via admin method, redirect view, `view_on_site_link_formatter` |
 | [Performance Optimization](#performance-optimization) | `Subquery` patterns, `ArrayAgg`, avoiding N+1 queries |
@@ -2496,6 +2496,7 @@ from django_smartbase_admin.engine.field_formatter import (
     array_badge_formatter,                  # Display list as horizontal badges
     newline_separated_array_badge_formatter, # Display list as vertical badges (one per line)
     boolean_formatter,                      # Yes/No badges
+    build_choice_formatter_for_field,       # Choice value → label (auto-assigned on choice fields)
     datetime_formatter,                     # Localized datetime
     datetime_formatter_with_format,         # Custom date/time format
     link_formatter,                         # Clickable URL
@@ -2503,6 +2504,8 @@ from django_smartbase_admin.engine.field_formatter import (
     format_array,                           # Custom badge formatting with BadgeType
 )
 ```
+
+`SBAdminField.init_field_static()` also auto-assigns `python_formatter` for date, boolean, and choice (`flatchoices`) model fields. Choice fields use `build_choice_formatter_for_field`. Set `python_formatter` explicitly or use an admin method to override.
 
 ### Array Badge Formatters
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-smartbase-admin"
-version = "2.0.9"
+version = "2.0.11"
 description = ""
 authors = ["SmartBase <info@smartbase.sk>"]
 readme = "README.md"

--- a/src/django_smartbase_admin/engine/field.py
+++ b/src/django_smartbase_admin/engine/field.py
@@ -17,9 +17,10 @@ from django.db.models.functions import Concat
 
 from django_smartbase_admin.engine.const import ANNOTATE_KEY, Formatter
 from django_smartbase_admin.engine.field_formatter import (
+    boolean_formatter,
+    build_choice_formatter_for_field,
     date_formatter,
     datetime_formatter,
-    boolean_formatter,
 )
 from django_smartbase_admin.engine.filter_widgets import (
     StringFilterWidget,
@@ -321,6 +322,10 @@ class SBAdminField(JSONSerializableMixin):
                 self.python_formatter = date_formatter
             elif isinstance(self.model_field, BooleanField):
                 self.python_formatter = boolean_formatter
+            elif getattr(self.model_field, "flatchoices", None):
+                self.python_formatter = build_choice_formatter_for_field(
+                    self.model_field, self.view.get_empty_value_display()
+                )
         self.filter_field = self.filter_field or self.field
         self.init_filter_for_field(configuration)
         self.initialized = True

--- a/src/django_smartbase_admin/engine/field.py
+++ b/src/django_smartbase_admin/engine/field.py
@@ -14,7 +14,6 @@ from django.db.models import (
     FilteredRelation,
 )
 from django.db.models.functions import Concat
-
 from django_smartbase_admin.engine.const import ANNOTATE_KEY, Formatter
 from django_smartbase_admin.engine.field_formatter import (
     boolean_formatter,
@@ -23,10 +22,11 @@ from django_smartbase_admin.engine.field_formatter import (
     datetime_formatter,
 )
 from django_smartbase_admin.engine.filter_widgets import (
-    StringFilterWidget,
+    AutocompleteFilterWidget,
     BooleanFilterWidget,
     DateFilterWidget,
-    AutocompleteFilterWidget,
+    MultipleChoiceFilterWidget,
+    StringFilterWidget,
 )
 from django_smartbase_admin.services.translations import SBAdminTranslationsService
 from django_smartbase_admin.services.xlsx_export import SBAdminXLSXFormat
@@ -205,12 +205,13 @@ class SBAdminField(JSONSerializableMixin):
         filter_widget = getattr(self, "filter_widget", None)
         if self.filter_disabled:
             return
-        if not filter_widget and getattr(self, "model_field", False):
-            filter_widget = StringFilterWidget.apply_to_field(self)
-            filter_widget = filter_widget or BooleanFilterWidget.apply_to_field(self)
-            filter_widget = filter_widget or DateFilterWidget.apply_to_field(self)
-            filter_widget = filter_widget or AutocompleteFilterWidget.apply_to_field(
-                self
+        if not filter_widget and getattr(self, "model_field", None):
+            filter_widget = (
+                BooleanFilterWidget.apply_to_field(self)
+                or DateFilterWidget.apply_to_field(self)
+                or AutocompleteFilterWidget.apply_to_field(self)
+                or MultipleChoiceFilterWidget.apply_to_field(self)
+                or StringFilterWidget.apply_to_field(self)
             )
         if not filter_widget:
             filter_widget = StringFilterWidget()

--- a/src/django_smartbase_admin/engine/field_formatter.py
+++ b/src/django_smartbase_admin/engine/field_formatter.py
@@ -1,9 +1,13 @@
 import datetime
+from collections.abc import Callable
 from enum import Enum
+from typing import Any
 
+from django.db.models import Field
 from django.template.defaultfilters import date, time
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.hashable import make_hashable
 from django.utils.html import format_html, format_html_join
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
@@ -59,6 +63,29 @@ def boolean_formatter(object_id, value):
     return format_html(
         '<span class="badge badge-simple badge-neutral">{}</span>', _("No")
     )
+
+
+def build_choice_formatter_for_field(
+    model_field: Field, empty_value_display: Any
+) -> Callable[[Any, Any], Any] | None:
+    """Build a formatter that resolves stored choice values to human-readable labels.
+
+    Mirrors ``django.contrib.admin.utils.display_for_field`` for fields with
+    ``flatchoices``.
+    """
+    flatchoices = getattr(model_field, "flatchoices", None)
+    if not flatchoices:
+        return None
+
+    def formatter(object_id, value):
+        try:
+            return dict(flatchoices).get(value, empty_value_display)
+        except TypeError:
+            return dict(make_hashable(flatchoices)).get(
+                make_hashable(value), empty_value_display
+            )
+
+    return formatter
 
 
 # Built-in formatters that produce locale-dependent strings. The MCP

--- a/src/django_smartbase_admin/engine/filter_widgets.py
+++ b/src/django_smartbase_admin/engine/filter_widgets.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
+
 import json
 from datetime import datetime, timedelta
+from typing import Self, TYPE_CHECKING
 
 from django import forms
 from django.core.exceptions import ImproperlyConfigured
 from django.contrib.postgres.fields import ArrayField
-from django.db.models import Q, fields, FilteredRelation, Count
+from django.db.models import Field, Q, fields, FilteredRelation, Count
 from django.http import JsonResponse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _, pgettext_lazy
@@ -29,6 +32,9 @@ from django_smartbase_admin.services.translations import SBAdminTranslationsServ
 from django_smartbase_admin.services.views import SBAdminViewService
 from django_smartbase_admin.templatetags.sb_admin_tags import SBAdminJSONEncoder
 from django_smartbase_admin.utils import JSONSerializableMixin
+
+if TYPE_CHECKING:
+    from django_smartbase_admin.engine.field import SBAdminField
 
 
 class AutocompleteParseMixin:
@@ -164,15 +170,15 @@ class SBAdminFilterWidget(JSONSerializableMixin):
         return self.default_label or self.get_default_value()
 
     @classmethod
-    def is_used_for_model_field_type(cls, model_field):
+    def is_used_for_model_field_type(cls, model_field: Field) -> bool:
         return False
 
     @classmethod
-    def apply_to_field(cls, field):
+    def apply_to_field(cls, field: SBAdminField) -> Self | None:
         return cls.apply_to_model_field(field.model_field)
 
     @classmethod
-    def apply_to_model_field(cls, model_field):
+    def apply_to_model_field(cls, model_field: Field) -> Self | None:
         if cls.is_used_for_model_field_type(model_field):
             return cls()
         return None
@@ -384,6 +390,16 @@ class MultipleChoiceFilterWidget(AutocompleteParseMixin, ChoiceFilterWidget):
             AllOperators.IS_NULL,
             AllOperators.IS_NOT_NULL,
         ]
+
+    @classmethod
+    def is_used_for_model_field_type(cls, model_field: Field) -> bool:
+        return bool(getattr(model_field, "flatchoices", None))
+
+    @classmethod
+    def apply_to_model_field(cls, model_field: Field) -> Self | None:
+        if cls.is_used_for_model_field_type(model_field):
+            return cls(choices=model_field.choices)
+        return None
 
 
 class NumberRangeFilterWidget(AutocompleteParseMixin, SBAdminFilterWidget):

--- a/src/django_smartbase_admin/engine/filter_widgets.py
+++ b/src/django_smartbase_admin/engine/filter_widgets.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timedelta
-from typing import Self, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from django import forms
 from django.core.exceptions import ImproperlyConfigured
@@ -32,6 +32,7 @@ from django_smartbase_admin.services.translations import SBAdminTranslationsServ
 from django_smartbase_admin.services.views import SBAdminViewService
 from django_smartbase_admin.templatetags.sb_admin_tags import SBAdminJSONEncoder
 from django_smartbase_admin.utils import JSONSerializableMixin
+from typing_extensions import Self
 
 if TYPE_CHECKING:
     from django_smartbase_admin.engine.field import SBAdminField

--- a/src/django_smartbase_admin/templates/sb_admin/filter_widgets/multiple_choice_field.html
+++ b/src/django_smartbase_admin/templates/sb_admin/filter_widgets/multiple_choice_field.html
@@ -40,4 +40,5 @@
             {% endfor %}
         {% endfor %}
     </ul>
+    {% include "sb_admin/filter_widgets/partials/clear.html" %}
 </div>


### PR DESCRIPTION
### **Summary**
SBAdmin list views showed raw database values (e.g. "pending") for model fields with choices, while the change view already displayed human-readable labels via Django’s display_for_field. This MR aligns list display and filtering with Django admin behavior for choice fields.

### **Changes**
**List column display**

- Add build_choice_formatter_for_field() in field_formatter.py, mirroring display_for_field (flatchoices lookup + make_hashable fallback for unhashable choice values).

- Auto-assign python_formatter in SBAdminField.init_field_static() when the model field has flatchoices and no explicit formatter or admin method is set.

- Empty/unknown values use ModelAdmin.get_empty_value_display() (same as Django admin).

**List filtering**

- Auto-assign MultipleChoiceFilterWidget for model fields with flatchoices.

- Fix filter widget detection order: choice fields were previously matched as CharField and got StringFilterWidget (icontains text search). Detection now runs boolean → date → autocomplete → choice → string.

- MultipleChoiceFilterWidget.apply_to_model_field() passes model_field.choices into the widget.

- Include the shared clear.html partial in multiple_choice_field.html so multiselect filters get Remove (hideFilter) and Clear (clearFilter) like string and single-choice filters.

**Documentation**

- Update AGENTS.md to note auto-assignment of both python_formatter and filter_widget for choice fields.

### **Motivation**
Fixes incorrect list rendering for choice columns such as Report.status and Report.verdict in Rewora, where raw enum values appeared in the changelist but labels appeared on the detail page. No per-admin formatter wiring is required for standard choice fields.

### **Override behavior**
Explicit python_formatter, admin display methods, or filter_widget on SBAdminField are left unchanged.