### PR TITLE
fix: correct dashboard title fallback and date filter widget defaults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-smartbase-admin"
-version = "2.0.16"
+version = "2.0.17"
 description = ""
 authors = ["SmartBase <info@smartbase.sk>"]
 readme = "README.md"

--- a/src/django_smartbase_admin/engine/filter_widgets.py
+++ b/src/django_smartbase_admin/engine/filter_widgets.py
@@ -609,7 +609,7 @@ class DateFilterWidget(SBAdminFilterWidget):
     def get_default_label(self):
         if self.default_value_shortcut_index is not None:
             return self.get_shortcuts()[self.default_value_shortcut_index]["label"]
-        return super().get_default_value()
+        return super().get_default_label()
 
     def get_default_value(self):
         if self.default_value_shortcut_index is not None:
@@ -713,7 +713,7 @@ class DateFilterWidget(SBAdminFilterWidget):
 
     @classmethod
     def get_value_from_date_or_range(cls, date_or_range):
-        if not isinstance(date_or_range, list):
+        if not isinstance(date_or_range, (list, tuple)):
             return datetime.strftime(date_or_range, cls.DATE_FORMAT)
         if type(date_or_range[0]) is int:
             return date_or_range

--- a/src/django_smartbase_admin/views/dashboard_view.py
+++ b/src/django_smartbase_admin/views/dashboard_view.py
@@ -17,7 +17,7 @@ class SBAdminDashboardView(SBAdminView):
     def __init__(self, title=None, widgets=None) -> None:
         super().__init__()
         self.widgets = widgets or self.widgets or []
-        self.title = title
+        self.title = title or self.title
 
     def get_title(self):
         return self.title or settings.PROJECT_NAME


### PR DESCRIPTION
Preserve class-level dashboard title when none is passed to __init__, call get_default_label() instead of get_default_value() in DateFilterWidget, and accept tuples as date ranges in get_value_from_date_or_range().