### PR TITLE
fix(admin): Support translated media fields

### DIFF
--- a/src/django_smartbase_admin/admin/admin_base.py
+++ b/src/django_smartbase_admin/admin/admin_base.py
@@ -185,7 +185,6 @@ class SBAdminFormFieldWidgetsMixin:
         forms.SplitDateTimeField: SBAdminSplitDateTimeWidget,
         forms.DateField: SBAdminDateWidget,
         forms.TimeField: SBAdminTimeWidget,
-        forms.Textarea: SBAdminTextareaWidget,
         forms.URLField: SBAdminURLFieldWidget,
         forms.IntegerField: SBAdminNumberWidget,
         forms.FloatField: SBAdminNumberWidget,
@@ -229,6 +228,7 @@ class SBAdminFormFieldWidgetsMixin:
     django_widget_to_widget = {
         forms.HiddenInput: SBAdminHiddenWidget,
         forms.PasswordInput: SBAdminPasswordInputWidget,
+        forms.Textarea: SBAdminTextareaWidget,
         AdminTextareaWidget: SBAdminTextareaWidget,
     }
 
@@ -263,14 +263,11 @@ class SBAdminFormFieldWidgetsMixin:
 
         if not widget:
             return form_field
-        choices = getattr(form_field, "choices", None)
         widget_attrs = form_field.widget.attrs
         widget_attrs.pop(
             "class", None
         )  # remove origin classes to prevent override our custom widget class
         kwargs = {}
-        if choices and widget != SBAdminHiddenWidget:
-            kwargs["choices"] = choices
         if isinstance(form_field, RichTextFormField):
             kwargs["config_name"] = getattr(
                 form_field.widget, "config_name", None
@@ -283,6 +280,8 @@ class SBAdminFormFieldWidgetsMixin:
                 form_field.widget, "extra_plugins", None
             ) or getattr(db_field, "extra_plugins", [])
         form_field.widget = widget(form_field=form_field, attrs=widget_attrs, **kwargs)
+        if hasattr(form_field, "choices") and hasattr(form_field.widget, "choices"):
+            form_field.widget.choices = form_field.choices
         return form_field
 
     def formfield_for_foreignkey(self, db_field, request, **kwargs):

--- a/src/django_smartbase_admin/admin/widgets.py
+++ b/src/django_smartbase_admin/admin/widgets.py
@@ -1042,7 +1042,7 @@ class SBAdminAutocompleteWidget(
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
         self.input_id = (
-            context["widget"]["attrs"]["id"] or f'id_{context["widget"]["name"]}'
+            context["widget"]["attrs"]["id"] or f"id_{context['widget']['name']}"
         )
 
         context["widget"]["type"] = "hidden"
@@ -1449,7 +1449,8 @@ class SBAdminImageWidget(SBAdminBaseWidget, AdminImageWidget):
     def __init__(self, form_field=None, *args, **kwargs):
         self.form_field = form_field
         super(AdminImageWidget, self).__init__(
-            form_field.rel, form_field.view.admin_site
+            form_field.rel,
+            form_field.view.admin_site,
         )
 
 
@@ -1470,7 +1471,10 @@ class SBAdminFilerPickerWidget(SBAdminBaseWidget, FilerAdminFileWidget):
         self.view = None
         self.request = None
         super(FilerAdminFileWidget, self).__init__(
-            form_field.rel, form_field.view.admin_site, *args, **kwargs
+            form_field.rel,
+            form_field.view.admin_site,
+            *args,
+            **kwargs,
         )
 
     def init_widget_dynamic(self, form, form_field, field_name, view, request):
@@ -1518,7 +1522,7 @@ class SBAdminFilerPickerWidget(SBAdminBaseWidget, FilerAdminFileWidget):
         return value
 
     def render(self, name, value, attrs=None, renderer=None):
-        attrs = {} if attrs is None else attrs.copy()
+        attrs = self.build_attrs(self.attrs, attrs)
         css_id = attrs.get("id", f"id_{name}")
         if "class" not in attrs:
             attrs["class"] = "vForeignKeyRawIdAdminField"
@@ -1531,6 +1535,7 @@ class SBAdminFilerPickerWidget(SBAdminBaseWidget, FilerAdminFileWidget):
         context = {
             "hidden_input": hidden_input,
             "id": css_id,
+            "selected_item_id": f"{css_id}-selected-item",
             "endpoint": (
                 f"{reverse('sb_admin:media_picker')}?picker_type={self.picker_type}"
             ),
@@ -1538,6 +1543,7 @@ class SBAdminFilerPickerWidget(SBAdminBaseWidget, FilerAdminFileWidget):
             "object": obj,
             "selected_item": selected_item,
             "picker_type": self.picker_type,
+            "is_readonly": bool(attrs.get("readonly") or attrs.get("disabled")),
         }
         return mark_safe(
             render_to_string("sb_admin/widgets/filer_picker.html", context)

--- a/src/django_smartbase_admin/engine/admin_base_view.py
+++ b/src/django_smartbase_admin/engine/admin_base_view.py
@@ -85,6 +85,7 @@ class SBAdminBaseView(object):
     widget_views = None
 
     def init_view_static(self, configuration, model, admin_site):
+        self.admin_site = admin_site
         self.init_widgets_static(configuration)
 
     def get_id(self):

--- a/src/django_smartbase_admin/engine/configuration.py
+++ b/src/django_smartbase_admin/engine/configuration.py
@@ -283,6 +283,8 @@ class SBAdminRoleConfiguration(metaclass=Singleton):
             view.init_view_static(self, None, sb_admin_site)
             sub_views = view.get_sub_views(self)
             if sub_views:
+                for sub_view in sub_views:
+                    sub_view.init_view_static(self, None, sb_admin_site)
                 registered_views.extend(sub_views)
         self.registered_views = registered_views
 

--- a/src/django_smartbase_admin/services/translations.py
+++ b/src/django_smartbase_admin/services/translations.py
@@ -79,6 +79,8 @@ class SBAdminTranslationsService(object):
                         field_val_bools = F(field_val_bool)
                     else:
                         field_val_bools += F(field_val_bool)
+                if field_val_bools is None:
+                    field_val_bools = Value(0, output_field=IntegerField())
                 annotates[f"{annotate_name}_count"] = field_val_bools
         queryset = queryset.annotate(**annotates)
         return queryset

--- a/src/django_smartbase_admin/services/translations.py
+++ b/src/django_smartbase_admin/services/translations.py
@@ -44,7 +44,11 @@ class SBAdminTranslationsService(object):
 
     @classmethod
     def annotate_queryset_with_translations_count(
-        cls, queryset, model, language_codes_to_annotate
+        cls,
+        queryset,
+        model,
+        language_codes_to_annotate,
+        translated_fields=None,
     ):
         annotates = {}
         for translation_model in model._parler_meta.get_all_models():
@@ -56,10 +60,9 @@ class SBAdminTranslationsService(object):
                     condition=Q(**{f"{rel_name}__language_code": language_code}),
                 )
                 field_val_bools = None
-                translated_fields_dict = (
-                    SBAdminTranslationsService.get_translated_fields_for_model(model)
-                )
-                for model_field in translated_fields_dict.get(translation_model, []):
+                if translated_fields is None:
+                    translated_fields = cls.get_translated_fields_for_model(model)
+                for model_field in translated_fields.get(translation_model, []):
                     field_val_bool = str(f"{annotate_name}_{model_field.name}_bool")
                     annotates[field_val_bool] = Case(
                         When(
@@ -125,15 +128,21 @@ class SBAdminTranslationsService(object):
         )
 
     @classmethod
-    def get_translated_fields_for_model(cls, model, visible_fields=None):
+    def get_translated_fields_for_model(
+        cls,
+        model,
+        visible_fields=None,
+        exclude_fields=None,
+    ):
         translated_fields = {}
         if not cls.is_translated_model(model):
             return translated_fields
+        excluded_fields = {*cls.parler_technical_fields, *(exclude_fields or ())}
         for translation_model in model._parler_meta.get_all_models():
             translated_fields[translation_model] = [
                 model_field
                 for model_field in translation_model._meta.get_fields()
-                if model_field.name not in cls.parler_technical_fields
+                if model_field.name not in excluded_fields
                 # if field is in visible fields or visible fields are empty
                 and (not visible_fields or model_field.name in visible_fields)
             ]

--- a/src/django_smartbase_admin/services/translations.py
+++ b/src/django_smartbase_admin/services/translations.py
@@ -63,8 +63,10 @@ class SBAdminTranslationsService(object):
                     field_val_bool = str(f"{annotate_name}_{model_field.name}_bool")
                     annotates[field_val_bool] = Case(
                         When(
-                            Q(**{f"{annotate_name}__{model_field.name}__isnull": False})
-                            & ~Q(**{f"{annotate_name}__{model_field.name}": ""}),
+                            cls.get_translation_field_value_condition(
+                                annotate_name,
+                                model_field,
+                            ),
                             then=Value(1),
                         ),
                         default=Value(0),
@@ -77,6 +79,14 @@ class SBAdminTranslationsService(object):
                 annotates[f"{annotate_name}_count"] = field_val_bools
         queryset = queryset.annotate(**annotates)
         return queryset
+
+    @classmethod
+    def get_translation_field_value_condition(cls, annotate_name, model_field):
+        field_name = f"{annotate_name}__{model_field.name}"
+        condition = Q(**{f"{field_name}__isnull": False})
+        if model_field.empty_strings_allowed:
+            condition &= ~Q(**{field_name: ""})
+        return condition
 
     @classmethod
     def is_translated_model(cls, model):

--- a/src/django_smartbase_admin/static/sb_admin/src/js/media_picker.js
+++ b/src/django_smartbase_admin/static/sb_admin/src/js/media_picker.js
@@ -1,6 +1,7 @@
 const PICKER_TYPE_IMAGE = 'image'
 const MODAL_SELECTOR = '#sb-admin-modal'
 const EMBEDDED_PICKER_SELECTOR = '[data-sb-media-picker-embed]'
+const SET_PICKER_VALUE_EVENT = 'sbadmin:media-picker:set-value'
 const EMBEDDED_MESSAGE_SOURCE = 'django-smartbase-admin:media-picker'
 const EMBEDDED_MESSAGE_TYPES = Object.freeze({
     BUSY: 'busy',
@@ -522,11 +523,20 @@ const initializeEmbeddedPicker = () => {
 
 document.addEventListener('click', (event) => {
     const trigger = event.target.closest('[data-sb-media-picker-trigger]')
-    if (trigger) initializePicker(trigger.closest('[data-sb-media-picker-widget]'))
+    const triggerWidget = trigger?.closest('[data-sb-media-picker-widget]')
+    if (trigger && triggerWidget?.dataset.pickerReadonly !== 'true') initializePicker(triggerWidget)
 
     const clear = event.target.closest('[data-picker-clear]')
-    if (clear) updateWidget(clear.closest('[data-sb-media-picker-widget]'), null)
+    const clearWidget = clear?.closest('[data-sb-media-picker-widget]')
+    if (clear && clearWidget?.dataset.pickerReadonly !== 'true') updateWidget(clearWidget, null)
 }, true)
+
+document.addEventListener(SET_PICKER_VALUE_EVENT, (event) => {
+    updateWidget(
+        event.target.closest('[data-sb-media-picker-widget]'),
+        event.detail?.item || null,
+    )
+})
 
 if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', initializeEmbeddedPicker, {once: true})

--- a/src/django_smartbase_admin/static/sb_admin/src/js/translations.js
+++ b/src/django_smartbase_admin/static/sb_admin/src/js/translations.js
@@ -3,7 +3,8 @@ class Translations {
         document.querySelectorAll('.js-copy-translation').forEach(button => {
             const input = button.closest('.js-translation-field-wrapper').querySelector('input, textarea')
             const mainInputID = `id_${button.dataset.mainLang}_${input.name}`
-            if(input.value) {
+            const mainInput = document.getElementById(mainInputID)
+            if(input.value || !mainInput?.value) {
                 return
             }
             button.removeAttribute('disabled')
@@ -12,8 +13,21 @@ class Translations {
                     window.CKEDITOR.instances[input.id].setData(window.CKEDITOR.instances[mainInputID].getData())
                     return
                 }
-                const mainInput = document.getElementById(mainInputID)
+                const targetPicker = input.closest('[data-sb-media-picker-widget]')
+                const mainPicker = mainInput.closest('[data-sb-media-picker-widget]')
+                if(targetPicker && mainPicker) {
+                    const item = JSON.parse(
+                        mainPicker.querySelector('script[type="application/json"]').textContent,
+                    )
+                    targetPicker.dispatchEvent(new CustomEvent('sbadmin:media-picker:set-value', {
+                        bubbles: true,
+                        detail: {item},
+                    }))
+                    return
+                }
                 input.value = mainInput.value
+                input.dispatchEvent(new Event('input', {bubbles: true}))
+                input.dispatchEvent(new Event('change', {bubbles: true}))
             })
         })
 

--- a/src/django_smartbase_admin/templates/sb_admin/actions/translations-detail.html
+++ b/src/django_smartbase_admin/templates/sb_admin/actions/translations-detail.html
@@ -49,7 +49,7 @@
                                         {{ field }}
                                         {% if not first_lang %}
                                             <div class="copy-translations-button-wrapper">
-                                                <button class="btn btn-icon w-40 px-0 js-copy-translation" data-main-lang="{{ main_language_code }}" title="{% trans 'Copy' %}" disabled>
+                                                <button type="button" class="btn btn-icon w-40 px-0 js-copy-translation" data-main-lang="{{ main_language_code }}" title="{% trans 'Copy' %}" disabled>
                                                     <svg class="w-10 h-10">
                                                         <use xlink:href="#Right-small"></use>
                                                     </svg>

--- a/src/django_smartbase_admin/templates/sb_admin/widgets/filer_picker.html
+++ b/src/django_smartbase_admin/templates/sb_admin/widgets/filer_picker.html
@@ -2,6 +2,8 @@
 
 <div class="sb-media-picker-widget"
      data-sb-media-picker-widget
+     data-picker-readonly="{% if is_readonly %}true{% else %}false{% endif %}"
+     {% if is_readonly %}aria-disabled="true"{% endif %}
      data-picker-type="{{ picker_type }}"
      data-choose-label="{% if picker_type == 'image' %}{% trans 'Choose image' %}{% else %}{% trans 'Choose file' %}{% endif %}"
      data-change-label="{% if picker_type == 'image' %}{% trans 'Change image' %}{% else %}{% trans 'Change file' %}{% endif %}">
@@ -10,7 +12,7 @@
             <div class="dz-thumbnail"><img class="quiet" data-dz-thumbnail></div>
             <div>
                 <span data-dz-name class="dz-name"></span>
-                <div class="flex items-center gap-4">
+                {% if not is_readonly %}<div class="flex items-center gap-4">
                     <span class="filerClearer" title="{% trans 'Clear' %}" data-dz-remove data-picker-clear
                           data-no-icon-file="{% static 'filer/icons/file-unknown.svg' %}">
                         <button type="button" class="btn btn-tiny btn-destructive">{% trans "Delete" %}</button>
@@ -20,7 +22,7 @@
                             hx-get="{{ endpoint }}" hx-target="#sb-admin-modal">
                         <span data-picker-trigger-label>{% if picker_type == "image" %}{% trans "Change image" %}{% else %}{% trans "Change file" %}{% endif %}</span>
                     </button>
-                </div>
+                </div>{% endif %}
             </div>
             <div class="dz-progress js-filer-dropzone-progress">
                 <span class="dz-upload" data-dz-uploadprogress></span>
@@ -28,8 +30,8 @@
         </span>
     </div>
 
-    <div class="js-filer-dropzone filer-dropzone{% if object %} js-object-attached{% endif %}"
-         data-picker-widget-dropzone data-url="{{ upload_url }}" data-max-files="1">
+    <div class="{% if not is_readonly %}js-filer-dropzone {% endif %}filer-dropzone{% if object %} js-object-attached{% endif %}"
+         data-picker-widget-dropzone{% if not is_readonly %} data-url="{{ upload_url }}"{% endif %} data-max-files="1">
         <div class="z-index-fix"></div>
         <div class="dz-default dz-message js-filer-dropzone-message{% if object %} hidden{% endif %}">
             <span class="w-64 h-64 flex items-center justify-center rounded-full mr-16 js-input-file-empty input-file-upload-icon">
@@ -46,7 +48,7 @@
                     {% trans "drop your file here or" %}
                 </span>
                 <span class="description_text" data-picker-preview-name>{% if object %}{{ object.label }}{% endif %}</span>
-                <div class="flex items-center gap-4">
+                {% if not is_readonly %}<div class="flex items-center gap-4">
                     <span class="filerClearer{% if not object %} hidden{% endif %}" title="{% trans 'Clear' %}"
                           data-picker-clear data-no-icon-file="{% static 'filer/icons/file-unknown.svg' %}">
                         <button type="button" class="btn btn-tiny btn-destructive">{% trans "Delete" %}</button>
@@ -62,10 +64,10 @@
                             {% endif %}
                         </span>
                     </button>
-                </div>
+                </div>{% endif %}
                 <div class="hidden">{{ hidden_input }}</div>
             </div>
         </span>
     </div>
-    {{ selected_item|json_script:id }}
+    {{ selected_item|json_script:selected_item_id }}
 </div>

--- a/src/django_smartbase_admin/tests/test_translation_widgets.py
+++ b/src/django_smartbase_admin/tests/test_translation_widgets.py
@@ -1,22 +1,43 @@
 from html.parser import HTMLParser
+from types import SimpleNamespace
+from unittest import mock
 
 from ckeditor_uploader.fields import RichTextUploadingField
 from django import forms
+from django.contrib.admin import AdminSite
 from django.db import models
 from django.forms import modelform_factory
 from django.template.loader import render_to_string
 from django.test import RequestFactory, SimpleTestCase
+from filer.fields.image import FilerImageField
+from filer.models import Image
 
-from django_smartbase_admin.admin.widgets import SBAdminCKEditorUploadingWidget
+from django_smartbase_admin.admin.widgets import (
+    SBAdminCKEditorUploadingWidget,
+    SBAdminFilerImagePickerWidget,
+    SBAdminMultipleChoiceInlineWidget,
+    SBAdminSelectWidget,
+    SBAdminTextareaWidget,
+)
+from django_smartbase_admin.services.translations import SBAdminTranslationsService
 from django_smartbase_admin.views.translations_view import ModelTranslationView
 
 
 class TranslatedArticle(models.Model):
     content = RichTextUploadingField(config_name="blog_config")
+    excerpt = models.TextField(blank=True)
 
     class Meta:
         app_label = "django_smartbase_admin"
         managed = False
+
+
+def get_image_model_field():
+    model_field = FilerImageField(null=True, on_delete=models.SET_NULL)
+    model_field.remote_field.model = Image
+    model_field.remote_field.field_name = Image._meta.pk.name
+    model_field.set_attributes_from_name("image")
+    return model_field
 
 
 class _TranslationDetailStructureParser(HTMLParser):
@@ -52,7 +73,80 @@ class _InvalidTranslationForm(forms.Form):
         raise forms.ValidationError("Translation constraint failed.")
 
 
+class _ChoicesProtocolWidget(forms.TextInput):
+    choices = ()
+
+    def __init__(self, form_field=None, attrs=None):
+        self.form_field = form_field
+        super().__init__(attrs)
+
+
 class TranslationWidgetTests(SimpleTestCase):
+    def test_default_choice_widgets_keep_field_choices(self):
+        choices = (("draft", "Draft"), ("published", "Published"))
+        cases = (
+            (forms.ChoiceField(choices=choices), SBAdminSelectWidget),
+            (forms.TypedChoiceField(choices=choices), SBAdminSelectWidget),
+            (
+                forms.MultipleChoiceField(choices=choices),
+                SBAdminMultipleChoiceInlineWidget,
+            ),
+            (
+                forms.TypedMultipleChoiceField(choices=choices),
+                SBAdminMultipleChoiceInlineWidget,
+            ),
+        )
+
+        for form_field, expected_widget_class in cases:
+            with self.subTest(form_field=form_field.__class__.__name__):
+                ModelTranslationView().assign_widget_to_form_field(form_field)
+
+                self.assertIsInstance(form_field.widget, expected_widget_class)
+                self.assertEqual(list(form_field.widget.choices), list(choices))
+
+    def test_choices_are_assigned_by_widget_protocol(self):
+        form_field = forms.ChoiceField(choices=(("draft", "Draft"),))
+        view = ModelTranslationView()
+        view.django_widget_to_widget = {
+            forms.Select: _ChoicesProtocolWidget,
+        }
+
+        view.assign_widget_to_form_field(form_field)
+
+        self.assertIsInstance(form_field.widget, _ChoicesProtocolWidget)
+        self.assertEqual(form_field.widget.choices, form_field.choices)
+
+    def test_translation_count_uses_non_null_check_for_relation_fields(self):
+        field = get_image_model_field()
+
+        condition = SBAdminTranslationsService.get_translation_field_value_condition(
+            "translation_en",
+            field,
+        )
+
+        self.assertEqual(
+            condition.children,
+            [("translation_en__image__isnull", False)],
+        )
+
+    def test_translation_count_uses_non_empty_check_for_text_fields(self):
+        field = TranslatedArticle._meta.get_field("content")
+
+        condition = SBAdminTranslationsService.get_translation_field_value_condition(
+            "translation_en",
+            field,
+        )
+
+        self.assertEqual(
+            condition.children[0],
+            ("translation_en__content__isnull", False),
+        )
+        self.assertTrue(condition.children[1].negated)
+        self.assertEqual(
+            condition.children[1].children,
+            [("translation_en__content", "")],
+        )
+
     def test_uploading_ckeditor_keeps_model_field_config(self):
         form_class = modelform_factory(TranslatedArticle, fields=("content",))
         form_field = form_class.base_fields["content"]
@@ -65,6 +159,69 @@ class TranslationWidgetTests(SimpleTestCase):
 
         self.assertIsInstance(form_field.widget, SBAdminCKEditorUploadingWidget)
         self.assertEqual(form_field.widget.config_name, "blog_config")
+
+    def test_text_field_keeps_textarea_widget(self):
+        form_class = modelform_factory(TranslatedArticle, fields=("excerpt",))
+        form_field = form_class.base_fields["excerpt"]
+        db_field = TranslatedArticle._meta.get_field("excerpt")
+
+        ModelTranslationView().assign_widget_to_form_field(
+            form_field,
+            db_field=db_field,
+        )
+
+        self.assertIsInstance(form_field.widget, SBAdminTextareaWidget)
+
+    def test_filer_image_widget_supports_translation_view(self):
+        db_field = get_image_model_field()
+        form_field = db_field.formfield()
+        form_field.widget.attrs["form"] = "translation-form-sk"
+        form_field.widget.attrs["readonly"] = True
+        admin_site = AdminSite(name="translation-test")
+        view = ModelTranslationView()
+        view.init_view_static(
+            SimpleNamespace(view_map={}),
+            TranslatedArticle,
+            admin_site,
+        )
+
+        view.assign_widget_to_form_field(
+            form_field,
+            db_field=db_field,
+        )
+
+        self.assertIsInstance(form_field.widget, SBAdminFilerImagePickerWidget)
+        self.assertIs(form_field.widget.admin_site, admin_site)
+        with (
+            mock.patch(
+                "django_smartbase_admin.admin.widgets.reverse",
+                return_value="/media-picker/",
+            ),
+            mock.patch.object(
+                form_field.widget,
+                "get_selected_object",
+                return_value=None,
+            ),
+            mock.patch(
+                "django_smartbase_admin.admin.widgets.FilerMediaPickerService.upload_url",
+                return_value="/upload/",
+            ),
+        ):
+            html = form_field.widget.render(
+                "meta_image",
+                None,
+                attrs={"id": "id_meta_image"},
+            )
+
+        self.assertIn('form="translation-form-sk"', html)
+        self.assertIn('data-picker-readonly="true"', html)
+        self.assertIn("readonly", html)
+        self.assertNotIn("data-sb-media-picker-trigger", html)
+        self.assertNotIn("data-picker-clear", html)
+        self.assertNotIn(">Delete<", html)
+        self.assertNotIn('class="js-filer-dropzone filer-dropzone', html)
+        self.assertEqual(html.count('id="id_meta_image"'), 1)
+        self.assertIn('id="id_meta_image-selected-item"', html)
 
     def test_non_field_errors_render_outside_translation_field_grid(self):
         form = _InvalidTranslationForm({"en-name": "Duplicate"}, prefix="en")

--- a/src/django_smartbase_admin/tests/test_translation_widgets.py
+++ b/src/django_smartbase_admin/tests/test_translation_widgets.py
@@ -82,6 +82,26 @@ class _ChoicesProtocolWidget(forms.TextInput):
 
 
 class TranslationWidgetTests(SimpleTestCase):
+    def test_translation_view_excludes_configured_model_fields(self):
+        included_field = mock.Mock(name="included_field")
+        included_field.name = "title"
+        excluded_field = mock.Mock(name="excluded_field")
+        excluded_field.name = "route_site"
+        translation_model = mock.Mock()
+        translation_model._meta.get_fields.return_value = (
+            included_field,
+            excluded_field,
+        )
+        model = mock.Mock()
+        model._parler_meta.get_all_models.return_value = (translation_model,)
+
+        translated_fields = ModelTranslationView(
+            model=model,
+            exclude_fields=("route_site",),
+        ).get_translated_fields()
+
+        self.assertEqual(translated_fields, {translation_model: [included_field]})
+
     def test_default_choice_widgets_keep_field_choices(self):
         choices = (("draft", "Draft"), ("published", "Published"))
         cases = (

--- a/src/django_smartbase_admin/tests/test_translation_widgets.py
+++ b/src/django_smartbase_admin/tests/test_translation_widgets.py
@@ -32,6 +32,37 @@ class TranslatedArticle(models.Model):
         managed = False
 
 
+class TranslationCountArticle(models.Model):
+    class Meta:
+        app_label = "django_smartbase_admin"
+        managed = False
+
+
+class TranslationCountArticleTranslation(models.Model):
+    master = models.ForeignKey(
+        TranslationCountArticle,
+        related_name="translations",
+        on_delete=models.CASCADE,
+    )
+    language_code = models.CharField(max_length=15)
+    content = models.TextField()
+
+    class Meta:
+        app_label = "django_smartbase_admin"
+        managed = False
+
+
+class _TranslationCountParlerMeta:
+    def get_all_models(self):
+        return (TranslationCountArticleTranslation,)
+
+    def __getitem__(self, translation_model):
+        return SimpleNamespace(rel_name="translations")
+
+
+TranslationCountArticle._parler_meta = _TranslationCountParlerMeta()
+
+
 def get_image_model_field():
     model_field = FilerImageField(null=True, on_delete=models.SET_NULL)
     model_field.remote_field.model = Image
@@ -82,6 +113,29 @@ class _ChoicesProtocolWidget(forms.TextInput):
 
 
 class TranslationWidgetTests(SimpleTestCase):
+    def test_translation_count_is_zero_when_all_fields_are_excluded(self):
+        translation_model = TranslationCountArticleTranslation
+        annotate_name = SBAdminTranslationsService.get_annotate_name(
+            translation_model,
+            "en",
+        )
+        translated_fields = SBAdminTranslationsService.get_translated_fields_for_model(
+            TranslationCountArticle,
+            exclude_fields=("content",),
+        )
+
+        queryset = SBAdminTranslationsService.annotate_queryset_with_translations_count(
+            TranslationCountArticle.objects.all(),
+            TranslationCountArticle,
+            ("en",),
+            translated_fields=translated_fields,
+        )
+
+        count_expression = queryset.query.annotations[f"{annotate_name}_count"]
+        self.assertIsInstance(count_expression, models.Value)
+        self.assertEqual(count_expression.value, 0)
+        self.assertIsInstance(count_expression.output_field, models.IntegerField)
+
     def test_translation_view_excludes_configured_model_fields(self):
         included_field = mock.Mock(name="included_field")
         included_field.name = "title"

--- a/src/django_smartbase_admin/views/translations_view.py
+++ b/src/django_smartbase_admin/views/translations_view.py
@@ -37,6 +37,7 @@ class ModelTranslationView(
     SBAdminBaseListView,
 ):
     translated_fields = None
+    exclude_fields = ()
     list_template_name = "sb_admin/actions/translations-list.html"
     FORM_BASE_ID = "translation-form-"
     TRANSLATION_NOT_TRANSLATED = 0
@@ -47,6 +48,10 @@ class ModelTranslationView(
         (TRANSLATION_INCOMPLETE, _("Incomplete")),
         (TRANSLATION_TRANSLATED, _("Translated")),
     ]
+
+    def __init__(self, *args, exclude_fields=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.exclude_fields = tuple(exclude_fields or self.exclude_fields)
 
     def get_sbadmin_list_view_config(self, request):
         result = []
@@ -106,7 +111,10 @@ class ModelTranslationView(
     def get_queryset(self, request=None):
         qs = super().get_queryset(request)
         qs = SBAdminTranslationsService.annotate_queryset_with_translations_count(
-            qs, self.model, self.get_display_language_codes(request)
+            qs,
+            self.model,
+            self.get_display_language_codes(request),
+            translated_fields=self.get_translated_fields(),
         )
         return qs
 
@@ -230,7 +238,10 @@ class ModelTranslationView(
             )
 
     def get_translated_fields(self):
-        return SBAdminTranslationsService.get_translated_fields_for_model(self.model)
+        return SBAdminTranslationsService.get_translated_fields_for_model(
+            self.model,
+            exclude_fields=self.exclude_fields,
+        )
 
     def handle_language_choice_change(self, request):
         if (
@@ -502,6 +513,10 @@ class SBAdminTranslationsView(SBAdminView):
                 }
                 if translation_definition.get("fields"):
                     view_class_params["fields"] = translation_definition.get("fields")
+                if translation_definition.get("exclude_fields"):
+                    view_class_params["exclude_fields"] = translation_definition.get(
+                        "exclude_fields"
+                    )
                 view = view_class(**view_class_params)
                 self.sub_views.append(view)
         return self.sub_views


### PR DESCRIPTION
Preserve choices when replacing form widgets and initialize registered subviews with the admin site. Copy media values between translations while
respecting read-only fields.